### PR TITLE
Add Codex blog post template

### DIFF
--- a/app/blog.py
+++ b/app/blog.py
@@ -1,6 +1,13 @@
 # This is not a clean implementation but it's kinda in line with the site design
 # It'll probably stay this way until I rewrite the whole site at some point
 posts = {
+    "codex-flask-dashboard": {
+        "title": "Building a Dashboard for ctbus_finance with Codex",
+        "date": "06/13/25",
+        "mod_date": "06/13/25",
+        "tags": ["codex", "flask", "python"],
+        "subtitle": "Using Codex to spin up a dashboard and fix some bugs.",
+    },
     "ctbus-finance": {
         "title": "Building a Simple Personal Finance App",
         "date": "04/07/25",

--- a/app/templates/blog/codex-flask-dashboard.html
+++ b/app/templates/blog/codex-flask-dashboard.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+{% import 'blog/blog.jinja' as blog %}
+
+{% block head %}
+<title>{{ title }}</title>
+<meta name="description" content="{{ subtitle }}" />
+{% endblock %}
+
+{% block body %}
+{% call blog.post_body() %}
+
+{{ blog.hero(title = title, subtitle = subtitle, tags = tags, date = date, mod_date = mod_date, img_link = img_link) }}
+
+{% call blog.section(header = "Background") %}
+<p class="text-lg text-left"></p>
+{% endcall %}
+
+{% call blog.section(header = "Using Codex") %}
+<p class="text-lg text-left"></p>
+{% endcall %}
+
+{% call blog.section(header = "Bug Fixes") %}
+<p class="text-lg text-left"></p>
+{% endcall %}
+{% endcall %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add metadata entry for a new Codex blog post
- scaffold blog post template for Codex-powered ctbus_finance dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684c8880fc1c8323ba406c3c2c25a9ba