### PR TITLE
Migrate pages to Vuetify styling

### DIFF
--- a/vue-frontend/src/components/Hero.vue
+++ b/vue-frontend/src/components/Hero.vue
@@ -1,13 +1,17 @@
 <template>
-  <div class="container mx-auto flex-1 mt-8 p-2 md:p-4 text-center md:w-1/2">
-    <h1 class="text-4xl font-bold mb-2">{{ title }}</h1>
-    <p class="text-lg" v-html="subtitle"></p>
-    <slot />
-  </div>
+  <v-container class="mt-8 text-center">
+    <v-row justify="center">
+      <v-col cols="12" md="6">
+        <h1 class="text-h4 font-weight-bold mb-2">{{ title }}</h1>
+        <p v-html="subtitle" class="text-subtitle-1"></p>
+        <slot />
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 <script setup>
 defineProps({
   title: String,
-  subtitle: String
-})
+  subtitle: String,
+});
 </script>

--- a/vue-frontend/src/components/SimplePage.vue
+++ b/vue-frontend/src/components/SimplePage.vue
@@ -1,14 +1,14 @@
 <template>
-  <div class="container mx-auto p-4 text-center">
-    <h1 class="text-2xl font-bold mb-2">{{ title }}</h1>
+  <v-container class="py-4 text-center">
+    <h1 class="text-h5 font-weight-bold mb-2">{{ title }}</h1>
     <slot />
-  </div>
+  </v-container>
 </template>
 <script setup>
 defineProps({
   title: {
     type: String,
-    required: true
-  }
-})
+    required: true,
+  },
+});
 </script>

--- a/vue-frontend/src/components/Timeline.vue
+++ b/vue-frontend/src/components/Timeline.vue
@@ -1,0 +1,33 @@
+<template>
+  <v-timeline align="start">
+    <v-timeline-item
+      v-for="(event, index) in events"
+      :key="index"
+      dot-color="primary"
+    >
+      <template #opposite>
+        {{ event.time }}
+      </template>
+      <div>
+        <h3 class="text-h6 font-weight-bold">{{ event.title }}</h3>
+        <p v-html="event.content" class="mb-2" />
+        <div v-if="event.link">
+          <router-link :to="event.link">
+            <v-btn color="primary" variant="outlined" size="small">
+              Learn more
+              <i class="fas fa-arrow-right ms-2"></i>
+            </v-btn>
+          </router-link>
+        </div>
+      </div>
+    </v-timeline-item>
+  </v-timeline>
+</template>
+<script setup>
+defineProps({
+  events: {
+    type: Array,
+    required: true,
+  },
+});
+</script>

--- a/vue-frontend/src/views/About.vue
+++ b/vue-frontend/src/views/About.vue
@@ -1,9 +1,59 @@
 <script setup>
-import SimplePage from '../components/SimplePage.vue'
+import Hero from '../components/Hero.vue'
+import Timeline from '../components/Timeline.vue'
+
+const timelineEvents = [
+  {
+    time: 'Jan 2022',
+    title: 'Developer in Statistical Metagenomics',
+    content:
+      'My position with the Penn-CHOP Microbiome Program has honed my <b>software development skills</b> and expanded my knowledge about <b>bioinformatics and statistics</b>. It has also shown me how to have an outsized impact on research and development on the basis of my unique skillset, namely driving software standards, encouraging well structured data/metadata, and building the infrastructure to support it.',
+    link: '/pcmp',
+  },
+  {
+    time: 'Jun 2021',
+    title: 'Lead Developer for Nightly',
+    content:
+      'This was where I experienced for the first time seeing something missing from the world and then creating a product to fill that gap. Before this, all my projects had been academic, the ends were just themselves and I knew they had been done before. After, I started to see every bad UX, every missing feature or platform, as opportunities and as gaps that I could conceivably fill. This was also the first time I had to take on the role of a <b>product owner</b> and spend more of my time thinking about the user experience than working out bugs.',
+    link: '/past-work#Lead%20Developer%20for%20Nightly',
+  },
+  {
+    time: 'Jun 2021',
+    title: 'Graduated Carleton College',
+    content:
+      'Physics Major.<br />GPA: 3.66.<br />Two years as captain of DIII frisbee team (best finish 3rd at nationals) and two years as head of the standup group.<br />Prototyped Nightly for startup competition and was among finalists.',
+  },
+  {
+    time: 'Jun 2020',
+    title: 'Internship at HPE',
+    content:
+      'At HPE I got to experience working with a <b>Scrum team</b> for the first time. Unlike with many other interns, my manager, after some training and certification, put me right to work as a member of the team which was awesome for so many reasons. I got to learn first hand how Scrum teams work (and sometimes don\'t work), both the theory and the practice of large scale <b>data pipelines</b>, and how to approach each unit of development work with the dual focuses of how to make it work in a vacuum and have it effectively integrate into the larger system.',
+    link: '/past-work#HPE%20Software%20Internship',
+  },
+  {
+    time: 'Jun 2018',
+    title: 'Internship at Owl Labs',
+    content:
+      'This internship was my first experience with a professional software environment. And it taught me a lot of skills that I now take for granted such as how to work at the command line, how to use git, and how to apply a <b>testing framework</b> to a large codebase.',
+    link: '/past-work#Owl%20Labs%20Software%20Internship',
+  },
+  {
+    time: 'Jul 2017',
+    title: 'Graduated Marblehead High School',
+    content: '',
+  },
+  {
+    time: 'Jul 2016',
+    title: 'Internship at HepatoChem',
+    content:
+      'I was fortunate to spend two summers and a winter of high school working with the awesome biochemists of HepatoChem. It was here that I first gained experience with lab work (just a little bit), practical database implementation, and the importance of good information infrastructure for <b>inventory management</b>. They were using Excel for all of their order and inventory management when I arrived and I was able to create a simple Access database that could handle the same tasks and compile safety data sheets for each kit. That system is still in use today.',
+    link: '/past-work#HepatoChem%20Software%20Internship',
+  },
+  { time: 'Oct 1998', title: 'I was born', content: 'Self explanatory.' },
+]
 </script>
 
 <template>
-  <SimplePage title="About Me">
-    <p>This is a placeholder about page converted from the Flask site.</p>
-  </SimplePage>
+  <Hero title="About Me" subtitle="Building the infrastructure behind <b>reliable</b>, <b>reproducible</b>, and <b>high performance</b> research and development." />
+  <Timeline :events="timelineEvents" />
 </template>

--- a/vue-frontend/src/views/BlogList.vue
+++ b/vue-frontend/src/views/BlogList.vue
@@ -3,13 +3,13 @@ import posts from '../data/posts.json'
 </script>
 
 <template>
-  <div class="container mx-auto p-4">
-    <h1 class="text-2xl font-bold mb-4">Blog</h1>
+  <v-container>
+    <h1 class="text-h5 font-weight-bold mb-4">Blog</h1>
     <div v-for="(post, name) in posts" :key="name" class="mb-4">
       <router-link :to="`/blog/${name}`" class="text-blue-600 underline">
         {{ post.title }}
       </router-link>
-      <p class="text-sm">{{ post.subtitle }}</p>
+      <p class="text-caption">{{ post.subtitle }}</p>
     </div>
-  </div>
+  </v-container>
 </template>

--- a/vue-frontend/src/views/BlogPost.vue
+++ b/vue-frontend/src/views/BlogPost.vue
@@ -13,5 +13,5 @@ const component = computed(() => {
 
 <template>
   <component :is="component" v-if="component" />
-  <div v-else class="container mx-auto p-4">Post not found.</div>
+  <v-container v-else>Post not found.</v-container>
 </template>

--- a/vue-frontend/src/views/Home.vue
+++ b/vue-frontend/src/views/Home.vue
@@ -1,6 +1,48 @@
 <script setup>
 import Hero from '../components/Hero.vue'
 const CDN_URL = window.CDN_URL || ''
+
+const certs = [
+  {
+    href: 'https://www.credly.com/badges/bcecce87-e9f9-4f05-a068-40eeb7474731/public_url',
+    src: `${CDN_URL}/certificates/aws_certified_cloud_practitioner.png`,
+    alt: 'AWS Certified Cloud Practitioner - Foundational',
+    h: 150,
+    w: 150,
+  },
+  {
+    href: 'https://www.credly.com/badges/a5cc21ee-a95c-4ba8-9a04-9f1f7e4928bf/public_url',
+    src: `${CDN_URL}/certificates/aws_certified_ai_practitioner_early_adopter.png`,
+    alt: 'AWS Certified AI Practitioner',
+    h: 180,
+    w: 180,
+  },
+  {
+    href: 'https://www.credly.com/badges/c6ee2c89-f5d2-46df-826e-b2246435709f/public_url',
+    src: `${CDN_URL}/certificates/aws_certified_developer_associate.png`,
+    alt: 'AWS Certified Developer - Associate',
+    h: 150,
+    w: 150,
+  },
+  {
+    href: 'https://www.credly.com/badges/3decec7b-025c-4f64-a461-01d7d0fd6c22/public_url',
+    src: `${CDN_URL}/certificates/aws_certified_devops_pro.png`,
+    alt: 'AWS Certified DevOps Engineer - Professional',
+    h: 150,
+    w: 150,
+  },
+]
+
+const buttons = [
+  { to: '/pcmp', label: 'Work', icon: 'fas fa-briefcase' },
+  { to: '/blog', label: 'Blog', icon: 'fas fa-code' },
+  { to: '/projects', label: 'Projects', icon: 'fas fa-project-diagram' },
+  { to: '/certifications', label: 'Certs', icon: 'fas fa-certificate' },
+  { to: '/education', label: 'Education', icon: 'fas fa-graduation-cap' },
+  { to: '/past-work', label: 'Past Work', icon: 'fas fa-history' },
+  { to: '/sports', label: 'Sports', icon: 'fas fa-football-ball' },
+  { to: '/music', label: 'Music', icon: 'fas fa-music' },
+]
 </script>
 
 <template>
@@ -8,51 +50,33 @@ const CDN_URL = window.CDN_URL || ''
     title="Charlie Bushman"
     subtitle="Full-Stack Software Engineer with Cloud, DevOps, and Python expertise. Impactful results pushing projects from ideation, to creation, to production. Always eager to learn new technologies, fields, and fun facts."
   >
-    <div class="flex flex-row justify-center items-center">
-      <a href="https://www.credly.com/badges/bcecce87-e9f9-4f05-a068-40eeb7474731/public_url" target="_blank">
-        <img :src="`${CDN_URL}/certificates/aws_certified_cloud_practitioner.png`" alt="AWS Certified Cloud Practitioner - Foundational" class="px-4" height="150" width="150" />
-      </a>
-      <a href="https://www.credly.com/badges/a5cc21ee-a95c-4ba8-9a04-9f1f7e4928bf/public_url" target="_blank">
-        <img :src="`${CDN_URL}/certificates/aws_certified_ai_practitioner_early_adopter.png`" alt="AWS Certified AI Practitioner" class="px-4" height="180" width="180" />
-      </a>
-      <a href="https://www.credly.com/badges/c6ee2c89-f5d2-46df-826e-b2246435709f/public_url" target="_blank">
-        <img :src="`${CDN_URL}/certificates/aws_certified_developer_associate.png`" alt="AWS Certified Developer - Associate" class="px-4" height="150" width="150" />
-      </a>
-      <a href="https://www.credly.com/badges/3decec7b-025c-4f64-a461-01d7d0fd6c22/public_url" target="_blank">
-        <img :src="`${CDN_URL}/certificates/aws_certified_devops_pro.png`" alt="AWS Certified DevOps Engineer - Professional" class="px-4" height="150" width="150" />
-      </a>
-    </div>
+    <v-row justify="center" class="my-4">
+      <v-col cols="auto" v-for="cert in certs" :key="cert.href">
+        <a :href="cert.href" target="_blank">
+          <v-img :src="cert.src" :alt="cert.alt" :height="cert.h" :width="cert.w" contain />
+        </a>
+      </v-col>
+    </v-row>
   </Hero>
 
-  <div class="container flex flex-wrap mx-auto md:w-1/2 p-4 justify-center items-center">
-    <router-link to="/pcmp" class="interest-button flex items-center bg-green-700 hover:bg-green-800 text-white text-lg font-bold font-mono py-2 px-4 rounded h-[40px] m-4">
-      Work&nbsp;&nbsp;&nbsp;&nbsp;<span class="ml-2"><i class="fas fa-briefcase"></i></span>
-    </router-link>
-    <router-link to="/blog" class="interest-button flex items-center bg-green-700 hover:bg-green-800 text-white text-lg font-bold font-mono py-2 px-4 rounded h-[40px] m-4">
-      Blog&nbsp;&nbsp;&nbsp;&nbsp;<span class="ml-2"><i class="fas fa-code"></i></span>
-    </router-link>
-    <router-link to="/projects" class="interest-button flex items-center bg-green-700 hover:bg-green-800 text-white text-lg font-bold font-mono py-2 px-4 rounded h-[50px] m-4">
-      Projects<span class="ml-2"><i class="fas fa-project-diagram"></i></span>
-    </router-link>
-    <router-link to="/certifications" class="interest-button flex items-center bg-green-700 hover:bg-green-800 text-white text-lg font-bold font-mono py-2 px-4 rounded h-[50px] m-4">
-      Certs&nbsp;&nbsp;&nbsp;<span class="ml-2"><i class="fas fa-certificate"></i></span>
-    </router-link>
-    <router-link to="/education" class="interest-button flex items-center bg-green-700 hover:bg-green-800 text-white text-lg font-bold font-mono py-2 px-4 rounded h-[50px] m-4">
-      Education<span class="ml-2"><i class="fas fa-graduation-cap"></i></span>
-    </router-link>
-    <router-link to="/past-work" class="interest-button flex items-center bg-green-700 hover:bg-green-800 text-white text-lg font-bold font-mono py-2 px-4 rounded h-[50px] m-4">
-      Past Work<span class="ml-2"><i class="fas fa-history"></i></span>
-    </router-link>
-    <router-link to="/sports" class="interest-button flex items-center bg-green-700 hover:bg-green-800 text-white text-lg font-bold font-mono py-2 px-4 rounded h-[50px] m-4">
-      Sports&nbsp;&nbsp;<span class="ml-2"><i class="fas fa-football-ball"></i></span>
-    </router-link>
-    <router-link to="/music" class="interest-button flex items-center bg-green-700 hover:bg-green-800 text-white text-lg font-bold font-mono py-2 px-4 rounded h-[40px] m-4">
-      Music&nbsp;&nbsp;&nbsp;<span class="ml-2"><i class="fas fa-music"></i></span>
-    </router-link>
-  </div>
+  <v-container class="text-center">
+    <v-row justify="center">
+      <v-col cols="auto" v-for="btn in buttons" :key="btn.to">
+        <router-link :to="btn.to">
+          <v-btn color="green-darken-2" class="ma-2" variant="elevated">
+            {{ btn.label }}
+            <i class="ms-2" :class="btn.icon"></i>
+          </v-btn>
+        </router-link>
+      </v-col>
+    </v-row>
+  </v-container>
 
-  <div class="container mx-auto p-4 text-center">
-    <h2 class="text-2xl font-bold mb-4">Get In Touch</h2>
-    <p class="mb-4">Feel free to reach out at <a href="mailto:ctbushman@gmail.com" class="font-medium text-blue-600 underline dark:text-blue-500 hover:no-underline">ctbushman@gmail.com</a></p>
-  </div>
+  <v-container class="text-center">
+    <h2 class="text-h6 font-weight-bold mb-4">Get In Touch</h2>
+    <p class="mb-4">
+      Feel free to reach out at
+      <a href="mailto:ctbushman@gmail.com">ctbushman@gmail.com</a>
+    </p>
+  </v-container>
 </template>

--- a/vue-frontend/src/views/PastWork.vue
+++ b/vue-frontend/src/views/PastWork.vue
@@ -1,9 +1,51 @@
 <script setup>
-import SimplePage from '../components/SimplePage.vue'
+import Hero from '../components/Hero.vue'
+const CDN_URL = window.CDN_URL || ''
+
+const workCards = [
+  {
+    title: 'Lead Developer for Nightly',
+    body: 'In college a friend pitched a party planning app for a startup competition. I built a prototype with React Native and AWS Amplify and later helped refine the web and mobile apps alongside a small team before joining the PCMP.',
+    img: `${CDN_URL}/images/latenite_logo.png`,
+  },
+  {
+    title: 'HPE Software Internship',
+    body: 'I worked with the GreenLake team on a large scale data migration pipeline, learning Scrum and tackling challenges around flexible data ingestion and processing.',
+    img: `${CDN_URL}/images/hpe_greenlake.png`,
+    link: 'https://hpe.com/us/en/greenlake.html',
+  },
+  {
+    title: 'Owl Labs Software Internship',
+    body: 'At Owl Labs I created a unit testing framework for their Meeting Owl firmware and later built internal inventory tools.',
+    img: `${CDN_URL}/images/owllabs.png`,
+    link: 'https://owllabs.com',
+  },
+  {
+    title: 'HepatoChem Software Internship',
+    body: 'During high school I built an Access database to manage inventory for HepatoChem\'s biomimetic screening kits.',
+    img: `${CDN_URL}/images/hepatochem.png`,
+    link: 'https://hepatochem.com',
+  },
+]
 </script>
 
 <template>
-  <SimplePage title="Past Work">
-    <p>Examples of previous projects and employment.</p>
-  </SimplePage>
+  <Hero title="My Previous Employment" />
+  <v-container>
+    <v-row justify="center">
+      <v-col cols="12" md="8" v-for="(card, i) in workCards" :key="i">
+        <v-card class="ma-4" :href="card.link" target="_blank">
+          <v-row no-gutters>
+            <v-col cols="12" md="4">
+              <v-img :src="card.img" :alt="card.title" height="160" contain />
+            </v-col>
+            <v-col cols="12" md="8">
+              <v-card-title>{{ card.title }}</v-card-title>
+              <v-card-text v-html="card.body"></v-card-text>
+            </v-col>
+          </v-row>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>

--- a/vue-frontend/src/views/ProjectDetail.vue
+++ b/vue-frontend/src/views/ProjectDetail.vue
@@ -13,5 +13,5 @@ const component = computed(() => {
 
 <template>
   <component :is="component" v-if="component" />
-  <div v-else class="container mx-auto p-4">Project not found.</div>
+  <v-container v-else>Project not found.</v-container>
 </template>

--- a/vue-frontend/src/views/ProjectsList.vue
+++ b/vue-frontend/src/views/ProjectsList.vue
@@ -3,13 +3,13 @@ import projects from '../data/projects.json'
 </script>
 
 <template>
-  <div class="container mx-auto p-4">
-    <h1 class="text-2xl font-bold mb-4">Projects</h1>
+  <v-container>
+    <h1 class="text-h5 font-weight-bold mb-4">Projects</h1>
     <div v-for="(proj, name) in projects" :key="name" class="mb-4">
       <router-link :to="`/projects/${name}`" class="text-blue-600 underline">
         {{ proj.title }}
       </router-link>
-      <p class="text-sm">{{ proj.subtitle }}</p>
+      <p class="text-caption">{{ proj.subtitle }}</p>
     </div>
-  </div>
+  </v-container>
 </template>

--- a/vue-frontend/src/views/Resume.vue
+++ b/vue-frontend/src/views/Resume.vue
@@ -7,7 +7,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="container mx-auto p-4 text-center">
+  <v-container class="text-center">
     <p>Redirecting to resume...</p>
-  </div>
+  </v-container>
 </template>

--- a/vue-frontend/src/views/SessionInfo.vue
+++ b/vue-frontend/src/views/SessionInfo.vue
@@ -10,11 +10,11 @@ function clearKey(key){
 </script>
 
 <template>
-  <div class="container mx-auto p-4">
-    <h1 class="text-2xl font-bold mb-4">Session Data</h1>
+  <v-container>
+    <h1 class="text-h5 font-weight-bold mb-4">Session Data</h1>
     <div v-for="(value,key) in sessionData" :key="key" class="mb-2">
       <span class="font-mono">{{ key }}: {{ value }}</span>
-      <button class="ml-2 text-blue-600 underline" @click="clearKey(key)">remove</button>
+      <v-btn variant="text" size="x-small" class="ml-2" @click="clearKey(key)">remove</v-btn>
     </div>
-  </div>
+  </v-container>
 </template>


### PR DESCRIPTION
## Summary
- introduce `Timeline` component for rendering timelines
- refactor `Hero` and `SimplePage` components to use Vuetify layout
- migrate Home, About, and Past Work content from Flask templates
- swap Tailwind containers in several views for Vuetify components

## Testing
- `pip install selenium requests boto3 python-dotenv webdriver-manager spotipy flask flask-sitemapper`
- `pytest -q` *(fails: Could not reach host for webdriver downloads and chess.com API)*

------
https://chatgpt.com/codex/tasks/task_e_685f53e187208323b7205c9109d6e7ce