### PR TITLE
Fix S3 uploads

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -29,14 +29,14 @@ locals {
 resource "aws_s3_object" "site" {
   for_each = local.processed_files
   bucket   = aws_s3_bucket.this.id
-  key      = each.value
-  source   = "${local.site_dir}/${each.value}"
+  key      = each.key
+  content  = each.value
   content_type = lookup(
     local.mime_types,
-    lower(element(reverse(split(".", each.value)), 0)),
+    lower(element(reverse(split(".", each.key)), 0)),
     "text/plain",
   )
-  etag = filemd5("${local.site_dir}/${each.value}")
+  etag = md5(each.value)
 }
 
 resource "aws_cloudfront_origin_access_identity" "this" {


### PR DESCRIPTION
## Summary
- fix terraform to use processed file content when uploading files to S3

## Testing
- `pytest -q` *(fails: Could not reach host chromedriver.storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_6862bbc34b748323b71f62702bd2a3a0