### PR TITLE
Fix timeline overlapping footer

### DIFF
--- a/vue-frontend/src/views/About.vue
+++ b/vue-frontend/src/views/About.vue
@@ -54,6 +54,11 @@ const timelineEvents = [
 </script>
 
 <template>
-  <Hero title="About Me" subtitle="Building the infrastructure behind <b>reliable</b>, <b>reproducible</b>, and <b>high performance</b> research and development." />
-  <Timeline :events="timelineEvents" />
+  <Hero
+    title="About Me"
+    subtitle="Building the infrastructure behind <b>reliable</b>, <b>reproducible</b>, and <b>high performance</b> research and development."
+  />
+  <v-container class="pt-0 pb-10">
+    <Timeline :events="timelineEvents" />
+  </v-container>
 </template>


### PR DESCRIPTION
## Summary
- prevent About timeline from overlapping footer

## Testing
- `pytest -q` *(fails: Could not reach host when running web tests)*

------
https://chatgpt.com/codex/tasks/task_e_6862cfc819b483239cc483d673e515f0