### PR TITLE
Fix JSON imports for blog and project pages

### DIFF
--- a/vue-frontend/src/data/posts.js
+++ b/vue-frontend/src/data/posts.js
@@ -1,4 +1,4 @@
-{
+export default {
   "ctbus-finance": {
     "title": "Building a Simple Personal Finance App",
     "date": "04/07/25",
@@ -132,4 +132,4 @@
     ],
     "subtitle": "My undergrad thesis! Read on for more."
   }
-}
+};

--- a/vue-frontend/src/data/projects.js
+++ b/vue-frontend/src/data/projects.js
@@ -1,4 +1,4 @@
-{
+export default {
   "ctbus-site": {
     "title": "CTBus Site",
     "subtitle": "A site for me. This site! Designed with Flask and Tailwind then deployed serverlessly on AWS using Zappa.",
@@ -51,4 +51,4 @@
     ],
     "image": "disctracker.png"
   }
-}
+};

--- a/vue-frontend/src/projects/ctbus-finance.vue
+++ b/vue-frontend/src/projects/ctbus-finance.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ProjectHero from '../components/ProjectHero.vue'
-import projects from '../data/projects.json'
+import projects from '../data/projects.js'
 
 const info = projects['ctbus-finance']
 const CDN_URL = 'CDN_URL'

--- a/vue-frontend/src/projects/ctbus-health.vue
+++ b/vue-frontend/src/projects/ctbus-health.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ProjectHero from '../components/ProjectHero.vue'
-import projects from '../data/projects.json'
+import projects from '../data/projects.js'
 
 const info = projects['ctbus-health']
 const CDN_URL = 'CDN_URL'

--- a/vue-frontend/src/projects/ctbus-site.vue
+++ b/vue-frontend/src/projects/ctbus-site.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ProjectHero from '../components/ProjectHero.vue'
-import projects from '../data/projects.json'
+import projects from '../data/projects.js'
 
 const info = projects['ctbus-site']
 const CDN_URL = 'CDN_URL'

--- a/vue-frontend/src/projects/disctracker.vue
+++ b/vue-frontend/src/projects/disctracker.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ProjectHero from '../components/ProjectHero.vue'
-import projects from '../data/projects.json'
+import projects from '../data/projects.js'
 
 const info = projects['disctracker']
 const CDN_URL = 'CDN_URL'

--- a/vue-frontend/src/projects/spotify-vis.vue
+++ b/vue-frontend/src/projects/spotify-vis.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ProjectHero from '../components/ProjectHero.vue'
-import projects from '../data/projects.json'
+import projects from '../data/projects.js'
 
 const info = projects['spotify-vis']
 const CDN_URL = 'CDN_URL'

--- a/vue-frontend/src/views/BlogList.vue
+++ b/vue-frontend/src/views/BlogList.vue
@@ -1,5 +1,5 @@
 <script setup>
-import posts from '../data/posts.json'
+import posts from '../data/posts.js'
 </script>
 
 <template>

--- a/vue-frontend/src/views/ProjectsList.vue
+++ b/vue-frontend/src/views/ProjectsList.vue
@@ -1,5 +1,5 @@
 <script setup>
-import projects from '../data/projects.json'
+import projects from '../data/projects.js'
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- convert posts and projects data to JS modules
- update imports in blog and project pages

## Testing
- `pytest -q` *(fails: Could not reach external resources)*

------
https://chatgpt.com/codex/tasks/task_e_6862cffc6cb48323b59c0d46febd05a0