### PR TITLE
Fix vue-sfc-loader imports

### DIFF
--- a/vue-frontend/index.html
+++ b/vue-frontend/index.html
@@ -14,6 +14,12 @@
     <script src="https://cdn.jsdelivr.net/npm/vue-router@4.5.1/dist/vue-router.global.prod.js" integrity="sha384-FDS5Foi3VsEhWeYrrGBf6c1kcG6lPhi+57Cd57EBDOp5m/Rvl2Sm5n7SKz2q8Sll" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/vuetify@3.8.10/dist/vuetify.min.js" integrity="sha384-urAAOfIFA65yosh73wWyHPAb2WPRsQ6tVB2lLGg3InOxNxvfJAwY4cTkOfsh2Jcf" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/vue3-sfc-loader@0.9.5/dist/vue3-sfc-loader.js" integrity="sha384-PZ/5Vu0PL2YXIi4MMqK0IC4MAQmOqYCJcT1COTIPapsnHFYqN3GW+pQdW7uVFCSm" crossorigin="anonymous"></script>
+    <script type="module">
+      import posts from './src/data/posts.js';
+      import projects from './src/data/projects.js';
+      window.posts = posts;
+      window.projects = projects;
+    </script>
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>

--- a/vue-frontend/src/projects/ctbus-finance.vue
+++ b/vue-frontend/src/projects/ctbus-finance.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ProjectHero from '../components/ProjectHero.vue'
-import projects from '../data/projects.js'
+const projects = window.projects
 
 const info = projects['ctbus-finance']
 const CDN_URL = 'CDN_URL'

--- a/vue-frontend/src/projects/ctbus-health.vue
+++ b/vue-frontend/src/projects/ctbus-health.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ProjectHero from '../components/ProjectHero.vue'
-import projects from '../data/projects.js'
+const projects = window.projects
 
 const info = projects['ctbus-health']
 const CDN_URL = 'CDN_URL'

--- a/vue-frontend/src/projects/ctbus-site.vue
+++ b/vue-frontend/src/projects/ctbus-site.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ProjectHero from '../components/ProjectHero.vue'
-import projects from '../data/projects.js'
+const projects = window.projects
 
 const info = projects['ctbus-site']
 const CDN_URL = 'CDN_URL'

--- a/vue-frontend/src/projects/disctracker.vue
+++ b/vue-frontend/src/projects/disctracker.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ProjectHero from '../components/ProjectHero.vue'
-import projects from '../data/projects.js'
+const projects = window.projects
 
 const info = projects['disctracker']
 const CDN_URL = 'CDN_URL'

--- a/vue-frontend/src/projects/spotify-vis.vue
+++ b/vue-frontend/src/projects/spotify-vis.vue
@@ -1,6 +1,6 @@
 <script setup>
 import ProjectHero from '../components/ProjectHero.vue'
-import projects from '../data/projects.js'
+const projects = window.projects
 
 const info = projects['spotify-vis']
 const CDN_URL = 'CDN_URL'

--- a/vue-frontend/src/views/BlogList.vue
+++ b/vue-frontend/src/views/BlogList.vue
@@ -1,5 +1,5 @@
 <script setup>
-import posts from '../data/posts.js'
+const posts = window.posts
 </script>
 
 <template>

--- a/vue-frontend/src/views/ProjectsList.vue
+++ b/vue-frontend/src/views/ProjectsList.vue
@@ -1,5 +1,5 @@
 <script setup>
-import projects from '../data/projects.js'
+const projects = window.projects
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- expose posts and projects data on `window` via index.html
- reference global data instead of importing JS modules in vue components

## Testing
- `pip install -r dev-requirements.txt`
- `pip install -r requirements.txt`
- `pip install selenium`
- `pip install webdriver_manager`
- `pytest -q` *(fails: ProxyError when downloading chromedriver and contacting api.chess.com)*

------
https://chatgpt.com/codex/tasks/task_e_6862d36ba07c8323a54e6bfa116cfa05