### PR TITLE
Fix dynamic component loading

### DIFF
--- a/vue-frontend/src/views/BlogPost.vue
+++ b/vue-frontend/src/views/BlogPost.vue
@@ -1,14 +1,29 @@
 <script setup>
 import { useRoute } from 'vue-router'
-import { computed } from 'vue'
+import { ref, watch } from 'vue'
 
 const route = useRoute()
-const posts = import.meta.glob('../posts/*.vue', { eager: true })
+const component = ref(null)
 
-const component = computed(() => {
-  const name = route.params.post
-  return posts[`../posts/${name}.vue`]
-})
+async function loadComponent() {
+  const name = route.params.slug
+  try {
+    component.value = await window['vue3-sfc-loader'].loadModule(
+      `${window.postsPath}/${name}.vue`,
+      window.loaderOptions,
+    )
+  } catch (e) {
+    component.value = null
+  }
+}
+
+watch(
+  () => route.params.slug,
+  () => {
+    loadComponent()
+  },
+  { immediate: true },
+)
 </script>
 
 <template>

--- a/vue-frontend/src/views/BlogPost.vue
+++ b/vue-frontend/src/views/BlogPost.vue
@@ -13,6 +13,7 @@ async function loadComponent() {
       window.loaderOptions,
     )
   } catch (e) {
+    console.error('Error loading component:', e)
     component.value = null
   }
 }

--- a/vue-frontend/src/views/ProjectDetail.vue
+++ b/vue-frontend/src/views/ProjectDetail.vue
@@ -1,14 +1,29 @@
 <script setup>
 import { useRoute } from 'vue-router'
-import { computed } from 'vue'
+import { ref, watch } from 'vue'
+
 const route = useRoute()
+const component = ref(null)
 
-const pages = import.meta.glob('../projects/*.vue', { eager: true })
+async function loadComponent() {
+  const name = route.params.slug
+  try {
+    component.value = await window['vue3-sfc-loader'].loadModule(
+      `${window.projectsPath}/${name}.vue`,
+      window.loaderOptions,
+    )
+  } catch (e) {
+    component.value = null
+  }
+}
 
-const component = computed(() => {
-  const name = route.params.project
-  return pages[`../projects/${name}.vue`]
-})
+watch(
+  () => route.params.slug,
+  () => {
+    loadComponent()
+  },
+  { immediate: true },
+)
 </script>
 
 <template>

--- a/vue-frontend/src/views/ProjectDetail.vue
+++ b/vue-frontend/src/views/ProjectDetail.vue
@@ -13,6 +13,7 @@ async function loadComponent() {
       window.loaderOptions,
     )
   } catch (e) {
+    console.error('Failed to load component:', e)
     component.value = null
   }
 }


### PR DESCRIPTION
## Summary
- handle loading blog posts without Vite's `import.meta.glob`
- handle loading project pages without Vite's `import.meta.glob`

## Testing
- `python -m pytest -q` *(fails: Could not reach host / ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_6862e6a58a5c83238584c2dfd2aae806