### PR TITLE
Add Spotify playlist fetch to music page

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,15 +22,23 @@ locals {
   site_dir   = "${path.root}/../vue-frontend"
   site_files = fileset(local.site_dir, "**")
   placeholders = {
-    "CDN_URL" = var.cdn_url
+    "CDN_URL"             = var.cdn_url
+    "SPOTIFY_CLIENT_ID"     = var.spotify_client_id
+    "SPOTIFY_CLIENT_SECRET" = var.spotify_client_secret
   }
 
   processed_files = {
     for f in local.site_files :
     f => replace(
-      file("${local.site_dir}/${f}"),
-      "CDN_URL", local.placeholders["CDN_URL"]
-    )
+          replace(
+            replace(
+              file("${local.site_dir}/${f}"),
+              "CDN_URL", local.placeholders["CDN_URL"]
+            ),
+            "SPOTIFY_CLIENT_ID", local.placeholders["SPOTIFY_CLIENT_ID"]
+          ),
+          "SPOTIFY_CLIENT_SECRET", local.placeholders["SPOTIFY_CLIENT_SECRET"]
+        )
   }
 
   mime_types = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -21,3 +21,14 @@ variable "zone_name" {
   description = "Route53 hosted zone to create the record in"
   default     = "charliebushman.com"
 }
+variable "spotify_client_id" {
+  type        = string
+  description = "Spotify API client ID"
+  default     = ""
+}
+
+variable "spotify_client_secret" {
+  type        = string
+  description = "Spotify API client secret"
+  default     = ""
+}

--- a/vue-frontend/src/views/Music.vue
+++ b/vue-frontend/src/views/Music.vue
@@ -1,10 +1,84 @@
 <script setup>
-import SimplePage from '../components/SimplePage.vue'
+import { ref, onMounted } from 'vue'
+import Hero from '../components/Hero.vue'
+
+const CLIENT_ID = 'SPOTIFY_CLIENT_ID'
+const CLIENT_SECRET = 'SPOTIFY_CLIENT_SECRET'
+
+const monthlies = ref([])
+
+async function fetchMonthlyPlaylists() {
+  try {
+    const tokenRes = await fetch('https://accounts.spotify.com/api/token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Authorization: 'Basic ' + btoa(`${CLIENT_ID}:${CLIENT_SECRET}`),
+      },
+      body: 'grant_type=client_credentials',
+    })
+    const tokenData = await tokenRes.json()
+    const token = tokenData.access_token
+
+    let url =
+      'https://api.spotify.com/v1/users/charlie_bushman/playlists?limit=50'
+    const playlists = []
+    while (url) {
+      const res = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      const data = await res.json()
+      playlists.push(...data.items.filter(Boolean))
+      url = data.next
+    }
+
+    const regex = /[A-Z][a-z]{2} ['‘]\d{2}/
+    const months = [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
+    ]
+
+    const filtered = playlists
+      .filter((p) => regex.test(p.name))
+      .map((p) => ({ ...p, name: p.name.replace('‘', "'") }))
+
+    filtered.sort((a, b) => {
+      const aYear = parseInt(a.name.slice(-2))
+      const bYear = parseInt(b.name.slice(-2))
+      if (aYear !== bYear) return bYear - aYear
+      const aMonth = months.indexOf(a.name.slice(0, 3))
+      const bMonth = months.indexOf(b.name.slice(0, 3))
+      return bMonth - aMonth
+    })
+
+    monthlies.value = filtered.map((p) => ({
+      name: p.name,
+      url: p.external_urls?.spotify || '#',
+      image: (p.images && p.images[2] && p.images[2].url) || '#',
+    }))
+  } catch (e) {
+    console.error('Failed to fetch playlists', e)
+  }
+}
+
+onMounted(fetchMonthlyPlaylists)
 </script>
 
 <template>
-  <SimplePage title="Music">
-    <p>Music sounds good. I listen to it a lot and sometimes try to make it. Top 0.05% of Jacob Collier listeners on Spotify for 4 years running. I play piano. I've also made playlists of my new music finds every month since January 2022, follow my Spotify to listen.</p>
+  <Hero
+    title="Music"
+    subtitle="Music sounds good. I listen to it a lot and sometimes try to make it. Top 0.05% of Jacob Collier listeners on Spotify for 4 years running. I play piano. I've also made playlists of my new music finds every month since January 2022, follow my Spotify to listen."
+  >
     <div class="d-flex justify-center my-4">
       <v-btn icon href="https://open.spotify.com/user/charlie_bushman?si=0dd732a8d6da46b6" target="_blank">
         <v-icon>mdi-spotify</v-icon>
@@ -13,5 +87,13 @@ import SimplePage from '../components/SimplePage.vue'
         <v-icon>mdi-web</v-icon>
       </v-btn>
     </div>
-  </SimplePage>
+    <div class="d-flex flex-wrap justify-center">
+      <div v-for="p in monthlies" :key="p.name" class="text-center ma-2">
+        <a :href="p.url" target="_blank" class="text-decoration-none">
+          <h2 class="text-subtitle-1 font-weight-bold">{{ p.name }}</h2>
+          <img :src="p.image" alt="Missing Playlist Graphic" width="80" height="80" class="rounded" />
+        </a>
+      </div>
+    </div>
+  </Hero>
 </template>


### PR DESCRIPTION
## Summary
- fetch monthly playlists directly from Spotify
- show playlists on the Music page
- add Spotify credentials variables in Terraform for placeholder replacement

## Testing
- `pytest -q` *(fails: ProxyError: Could not reach host)*

------
https://chatgpt.com/codex/tasks/task_e_6862e83e9c6c8323905ed6e441df47d3