### PR TITLE
Fix relative paths for dynamic Vue components

### DIFF
--- a/vue-frontend/src/main.js
+++ b/vue-frontend/src/main.js
@@ -17,15 +17,16 @@ const options = {
     },
   };
   window.loaderOptions = options;
-  window.componentsPath = './src/components';
-  window.viewsPath = './src/views';
-  window.postsPath = './src/posts';
-  window.projectsPath = './src/projects';
-  window.dataPath = './src/data';
+  // use absolute paths so navigation from nested routes works correctly
+  window.componentsPath = '/src/components';
+  window.viewsPath = '/src/views';
+  window.postsPath = '/src/posts';
+  window.projectsPath = '/src/projects';
+  window.dataPath = '/src/data';
   
   (async () => {
     const [App] = await Promise.all([
-      window['vue3-sfc-loader'].loadModule('./src/App.vue', options),
+      window['vue3-sfc-loader'].loadModule('/src/App.vue', options),
     ]);
   
     const router = VueRouter.createRouter({


### PR DESCRIPTION
## Summary
- use root-relative paths in main.js so dynamic components resolve correctly from nested routes

## Testing
- `pytest -q` *(fails: could not reach host for chromedriver and chess API)*

------
https://chatgpt.com/codex/tasks/task_e_6862ea83fde48323b65d6a0cb27c4778