### PR TITLE
Fix CDN_URL placeholder usage

### DIFF
--- a/vue-frontend/src/posts/cicd-pipeline.vue
+++ b/vue-frontend/src/posts/cicd-pipeline.vue
@@ -1,6 +1,5 @@
 <script setup>
 import SimplePage from '../components/SimplePage.vue'
-const CDN_URL = window.CDN_URL || ''
 </script>
 
 <template>
@@ -416,7 +415,7 @@ const CDN_URL = window.CDN_URL || ''
     </pre>
     <h3 >Conclusions</h3>
     <p >I wasn't convinced this would actually be useful at the start of this project. It was more of a learning project and something that might come in handy if this site ever scales up significatly. But I was absolutely wrong! Just in the process of building the PR to add this workflow I caught so many things that I normally wouldn't until later down the line or at all. I could see within minutes whether or not site configuration changes had messed up the actual deployment. I made low contrast elements and images without alt text more accessible. I added Content Security Policy headers to prevent common attacks. The positive impact that this pipeline has had on my web app practices and should continue to have on this site when I forget these practices in the future or encounter new terrain is enourmous.</p>
-    <img src="${CDN_URL}/images/ctbus_site_cd_workflow_success.png" alt="CI/CD Workflow Success" >
+    <img src="CDN_URL/images/ctbus_site_cd_workflow_success.png" alt="CI/CD Workflow Success" >
     <p >And it's free. As long as the project is open source on GitHub, I have as much GHA runner usage as I can handle. If you have a web app deployed through zappa, there's almost no downside to implementing a similar CI/CD pipeline to improve the quality, security, and accessibility of your app.</p>
   </SimplePage>
 </template>

--- a/vue-frontend/src/posts/comps.vue
+++ b/vue-frontend/src/posts/comps.vue
@@ -1,6 +1,5 @@
 <script setup>
 import SimplePage from '../components/SimplePage.vue'
-const CDN_URL = window.CDN_URL || ''
 </script>
 
 <template>

--- a/vue-frontend/src/posts/ctbus-finance.vue
+++ b/vue-frontend/src/posts/ctbus-finance.vue
@@ -1,6 +1,5 @@
 <script setup>
 import SimplePage from '../components/SimplePage.vue'
-const CDN_URL = window.CDN_URL || ''
 </script>
 
 <template>

--- a/vue-frontend/src/posts/discovering-prefect.vue
+++ b/vue-frontend/src/posts/discovering-prefect.vue
@@ -1,6 +1,5 @@
 <script setup>
 import SimplePage from '../components/SimplePage.vue'
-const CDN_URL = window.CDN_URL || ''
 </script>
 
 <template>

--- a/vue-frontend/src/posts/disctracker.vue
+++ b/vue-frontend/src/posts/disctracker.vue
@@ -1,6 +1,5 @@
 <script setup>
 import SimplePage from '../components/SimplePage.vue'
-const CDN_URL = window.CDN_URL || ''
 </script>
 
 <template>

--- a/vue-frontend/src/posts/firewalls-in-china.vue
+++ b/vue-frontend/src/posts/firewalls-in-china.vue
@@ -1,6 +1,5 @@
 <script setup>
 import SimplePage from '../components/SimplePage.vue'
-const CDN_URL = window.CDN_URL || ''
 </script>
 
 <template>

--- a/vue-frontend/src/posts/flask-sessions.vue
+++ b/vue-frontend/src/posts/flask-sessions.vue
@@ -1,6 +1,5 @@
 <script setup>
 import SimplePage from '../components/SimplePage.vue'
-const CDN_URL = window.CDN_URL || ''
 </script>
 
 <template>

--- a/vue-frontend/src/posts/fully-serverless-data-pipeline.vue
+++ b/vue-frontend/src/posts/fully-serverless-data-pipeline.vue
@@ -1,6 +1,5 @@
 <script setup>
 import SimplePage from '../components/SimplePage.vue'
-const CDN_URL = window.CDN_URL || ''
 </script>
 
 <template>

--- a/vue-frontend/src/posts/multi-dev-deployment.vue
+++ b/vue-frontend/src/posts/multi-dev-deployment.vue
@@ -1,6 +1,5 @@
 <script setup>
 import SimplePage from '../components/SimplePage.vue'
-const CDN_URL = window.CDN_URL || ''
 </script>
 
 <template>

--- a/vue-frontend/src/posts/qkd.vue
+++ b/vue-frontend/src/posts/qkd.vue
@@ -1,6 +1,5 @@
 <script setup>
 import SimplePage from '../components/SimplePage.vue'
-const CDN_URL = window.CDN_URL || ''
 </script>
 
 <template>

--- a/vue-frontend/src/posts/serverless-dashboards-with-dash.vue
+++ b/vue-frontend/src/posts/serverless-dashboards-with-dash.vue
@@ -1,6 +1,5 @@
 <script setup>
 import SimplePage from '../components/SimplePage.vue'
-const CDN_URL = window.CDN_URL || ''
 </script>
 
 <template>

--- a/vue-frontend/src/posts/thematic-image-generation.vue
+++ b/vue-frontend/src/posts/thematic-image-generation.vue
@@ -1,6 +1,5 @@
 <script setup>
 import SimplePage from '../components/SimplePage.vue'
-const CDN_URL = window.CDN_URL || ''
 </script>
 
 <template>

--- a/vue-frontend/src/projects/ctbus-finance.vue
+++ b/vue-frontend/src/projects/ctbus-finance.vue
@@ -3,7 +3,6 @@ import ProjectHero from '../components/ProjectHero.vue'
 const projects = window.projects
 
 const info = projects['ctbus-finance']
-const CDN_URL = 'CDN_URL'
 </script>
 
 <template>
@@ -11,7 +10,7 @@ const CDN_URL = 'CDN_URL'
     :title="info.title"
     :subtitle="info.subtitle"
     :tags="info.tags"
-    :img="`${CDN_URL}/images/${info.image}`"
+    :img="`CDN_URL/images/${info.image}`"
   />
   <v-container>
     <h2 class="text-h6 font-weight-bold mb-2">Overview</h2>

--- a/vue-frontend/src/projects/ctbus-health.vue
+++ b/vue-frontend/src/projects/ctbus-health.vue
@@ -3,7 +3,6 @@ import ProjectHero from '../components/ProjectHero.vue'
 const projects = window.projects
 
 const info = projects['ctbus-health']
-const CDN_URL = 'CDN_URL'
 </script>
 
 <template>
@@ -11,7 +10,7 @@ const CDN_URL = 'CDN_URL'
     :title="info.title"
     :subtitle="info.subtitle"
     :tags="info.tags"
-    :img="`${CDN_URL}/images/${info.image}`"
+    :img="`CDN_URL/images/${info.image}`"
   />
   <v-container>
     <h2 class="text-h6 font-weight-bold mb-2">Overview</h2>

--- a/vue-frontend/src/projects/disctracker.vue
+++ b/vue-frontend/src/projects/disctracker.vue
@@ -3,7 +3,6 @@ import ProjectHero from '../components/ProjectHero.vue'
 const projects = window.projects
 
 const info = projects['disctracker']
-const CDN_URL = 'CDN_URL'
 </script>
 
 <template>
@@ -11,7 +10,7 @@ const CDN_URL = 'CDN_URL'
     :title="info.title"
     :subtitle="info.subtitle"
     :tags="info.tags"
-    :img="`${CDN_URL}/images/${info.image}`"
+    :img="`CDN_URL/images/${info.image}`"
   />
   <v-container>
     <h2 class="text-h6 font-weight-bold mb-2">Overview</h2>

--- a/vue-frontend/src/projects/spotify-vis.vue
+++ b/vue-frontend/src/projects/spotify-vis.vue
@@ -3,7 +3,6 @@ import ProjectHero from '../components/ProjectHero.vue'
 const projects = window.projects
 
 const info = projects['spotify-vis']
-const CDN_URL = 'CDN_URL'
 </script>
 
 <template>
@@ -11,7 +10,7 @@ const CDN_URL = 'CDN_URL'
     :title="info.title"
     :subtitle="info.subtitle"
     :tags="info.tags"
-    :img="`${CDN_URL}/images/${info.image}`"
+    :img="`CDN_URL/images/${info.image}`"
   />
   <v-container>
     <h2 class="text-h6 font-weight-bold mb-2">Overview</h2>


### PR DESCRIPTION
## Summary
- remove faulty `window.CDN_URL` references
- use direct `CDN_URL` placeholder for blog and project images

## Testing
- `black . --check` *(fails: would reformat app/blog.py)*

------
https://chatgpt.com/codex/tasks/task_e_6862f7d13378832383074e078b5dfc39