### PR TITLE
Update resume page behavior

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -216,7 +216,7 @@ def about():
 )
 @app.route("/resume")
 def resume():
-    return redirect(f"{CDN_URL}/documents/resume.pdf")
+    return render_template("resume.html")
 
 
 @app.route("/favorite-number")

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -56,7 +56,7 @@
                     {{ svgs.data(class="w-8 h-8") }}
                 </a>
                 <!-- Resume Download -->
-                <a href="{{ cdn_url }}/documents/resume.pdf" target="_blank" class="text-white" title="Download R&eacute;sum&eacute;">
+                <a href="{{ url_for('resume') }}" class="text-white" title="Download R&eacute;sum&eacute;">
                     {{ svgs.download_file(class="w-8 h-8") }}
                 </a>
                 <!-- GitHub Link -->

--- a/app/templates/resume.html
+++ b/app/templates/resume.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+
+{% block head %}
+<title>Résumé</title>
+<script>
+  window.addEventListener('DOMContentLoaded', () => {
+    window.open('{{ cdn_url }}/documents/resume.pdf', '_blank');
+  });
+</script>
+{% endblock %}
+
+{% block body %}
+<div class="flex-grow flex items-center justify-center p-10">
+  <div class="bg-white p-8 rounded-lg shadow-md text-center">
+      <p>Opening résumé...</p>
+      <p>If nothing happens, <a href="{{ cdn_url }}/documents/resume.pdf" target="_blank">click here</a>.</p>
+  </div>
+</div>
+{% endblock %}

--- a/vue-frontend/src/views/Resume.vue
+++ b/vue-frontend/src/views/Resume.vue
@@ -2,12 +2,12 @@
 import { onMounted } from 'vue'
 
 onMounted(() => {
-  window.location.href = 'CDN_URL/documents/resume.pdf'
+  window.open('CDN_URL/documents/resume.pdf', '_blank')
 })
 </script>
 
 <template>
   <v-container class="text-center">
-    <p>Redirecting to resume...</p>
+    <p>Opening resume...</p>
   </v-container>
 </template>


### PR DESCRIPTION
## Summary
- open resume PDF in new tab from Vue
- add server template to open resume
- hook resume template to Flask route
- update navbar resume link

## Testing
- `terraform --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862fc079b048323a7b70a1ec6471b1b