### PR TITLE
Display tags and dates in listings; add hero to blog posts

### DIFF
--- a/vue-frontend/src/components/BlogHero.vue
+++ b/vue-frontend/src/components/BlogHero.vue
@@ -1,0 +1,34 @@
+<template>
+  <v-container class="my-4">
+    <v-row align="center">
+      <v-col cols="auto">
+        <v-img :src="img" :alt="title" width="120" height="120" class="rounded" />
+      </v-col>
+      <v-col>
+        <h1 class="text-h5 font-weight-bold mb-2">{{ title }}</h1>
+        <p class="text-subtitle-1 mb-1">{{ subtitle }}</p>
+        <div class="text-caption mb-1">{{ date }}</div>
+        <div>
+          <v-chip
+            v-for="tag in tags"
+            :key="tag"
+            class="ma-1"
+            size="small"
+            variant="outlined"
+          >
+            {{ tag }}
+          </v-chip>
+        </div>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+<script setup>
+defineProps({
+  title: String,
+  subtitle: String,
+  date: String,
+  tags: Array,
+  img: String,
+});
+</script>

--- a/vue-frontend/src/posts/cicd-pipeline.vue
+++ b/vue-frontend/src/posts/cicd-pipeline.vue
@@ -1,9 +1,19 @@
 <script setup>
-import SimplePage from '../components/SimplePage.vue'
+import BlogHero from '../components/BlogHero.vue'
+import posts from '../data/posts.js'
+const slug = 'cicd-pipeline'
+const info = posts[slug]
 </script>
 
 <template>
-  <SimplePage title="CI/CD Pipeline with GitHub Actions">
+  <BlogHero
+    :title="info.title"
+    :subtitle="info.subtitle"
+    :date="info.date"
+    :tags="info.tags"
+    :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
+  />
+  <v-container class="py-4">
     <p >Deploying a zappa site takes time. Not that much, a couple minutes, but it means that it's a pain to do regularly which means that I didn't do it regularly. Instead I developed and tested with a local version and then would push straight to production once that was where I wanted it. And that approach worked, but it had some downsides, such as having to manually deploy changes (even just once in a while) and not catching deployment issues early (like installing huge dependencies and having lambda reject the package for being too big). These are the kind of issues that scale with complexity so I figured I'd get a jumpstart and automate as much as I could now, get the infrastructure in place to go above and beyond the project's CI/CD needs. The end goal is a pipeline like this: version control -> tests/static analysis -> build & push artifact -> dev deployment -> test dev deployment -> prod deployment (on PR merge)</p>
     <h3 >Starting with Simple CI</h3>
     <p >As a starting point, I need to implement some basic CI workflows, which I'm already familiar with from developing scientific software packages. I use GitHub Actions (GHA) for everything cause that's what I'm used to. Adding a unit testing workflow with PyTest is relatively straightforward:</p>
@@ -417,5 +427,5 @@ import SimplePage from '../components/SimplePage.vue'
     <p >I wasn't convinced this would actually be useful at the start of this project. It was more of a learning project and something that might come in handy if this site ever scales up significatly. But I was absolutely wrong! Just in the process of building the PR to add this workflow I caught so many things that I normally wouldn't until later down the line or at all. I could see within minutes whether or not site configuration changes had messed up the actual deployment. I made low contrast elements and images without alt text more accessible. I added Content Security Policy headers to prevent common attacks. The positive impact that this pipeline has had on my web app practices and should continue to have on this site when I forget these practices in the future or encounter new terrain is enourmous.</p>
     <img src="CDN_URL/images/ctbus_site_cd_workflow_success.png" alt="CI/CD Workflow Success" >
     <p >And it's free. As long as the project is open source on GitHub, I have as much GHA runner usage as I can handle. If you have a web app deployed through zappa, there's almost no downside to implementing a similar CI/CD pipeline to improve the quality, security, and accessibility of your app.</p>
-  </SimplePage>
+  </v-container>
 </template>

--- a/vue-frontend/src/posts/comps.vue
+++ b/vue-frontend/src/posts/comps.vue
@@ -1,9 +1,19 @@
 <script setup>
-import SimplePage from '../components/SimplePage.vue'
+import BlogHero from '../components/BlogHero.vue'
+import posts from '../data/posts.js'
+const slug = 'comps'
+const info = posts[slug]
 </script>
 
 <template>
-  <SimplePage title="Physical Reservoir Computing for Classification of Temporal Data">
+  <BlogHero
+    :title="info.title"
+    :subtitle="info.subtitle"
+    :date="info.date"
+    :tags="info.tags"
+    :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
+  />
+  <v-container class="py-4">
     <!-- Plotly -->
     <script src="https://cdn.plot.ly/plotly-2.26.0.min.js" integrity="sha384-xuh4dD2xC9BZ4qOrUrLt8psbgevXF2v+K+FrXxV4MlJHnWKgnaKoh74vd/6Ik8uF" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js" integrity="sha512-vc58qvvBdrDR4etbxMdlTt4GBQk1qjvyORR2nrsPsFPyrs+/u5c3+1Ct6upOgdZoIl7eq6k3a1UPDSNAQi/32A==" crossorigin="anonymous"></script>
@@ -50,5 +60,5 @@ import SimplePage from '../components/SimplePage.vue'
     <script src=""></script>
     <p >It is a time delayed system, which means it relies on previous values of itself to determine its present dynamics. It is inspired by biological systems and is also the model used by <a href="https://www.nature.com/articles/ncomms1476" target="_blank" >L. Appeltant in his thesis work developing the first example of a physical system being used for reservoir computing</a>. He (and later in a class taught by <a href="https://umdphysics.umd.edu/people/faculty/current/item/445-rroy.html" target="_blank" >Rajarshi Roy</a>, I) mimicked this sytem's dynamics with a nonlinear, optoelectronic circuit to act as a physical reservoir computer.</p>
     <p >In the paper I also explore a mechanical system being used as a reservoir (a bunch of masses and springs) and a quantum computer being used as a reservoir. Maybe I'll write more about those here in the future.</p>
-  </SimplePage>
+  </v-container>
 </template>

--- a/vue-frontend/src/posts/ctbus-finance.vue
+++ b/vue-frontend/src/posts/ctbus-finance.vue
@@ -1,9 +1,19 @@
 <script setup>
-import SimplePage from '../components/SimplePage.vue'
+import BlogHero from '../components/BlogHero.vue'
+import posts from '../data/posts.js'
+const slug = 'ctbus-finance'
+const info = posts[slug]
 </script>
 
 <template>
-  <SimplePage title="Building a Simple Personal Finance App">
+  <BlogHero
+    :title="info.title"
+    :subtitle="info.subtitle"
+    :date="info.date"
+    :tags="info.tags"
+    :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
+  />
+  <v-container class="py-4">
     <p >It's all well and good to keep playing around with the newest technologies; make everything serverless, highly-available, and AI-driven. But sometimes a simple application of a couple really old tools is all you need to get a job done and it's always good to stay in practice with them too.</p>
     <p >I'd been considering potential designs for a personal finance app. Thinking thoughts like: how do I secure automated exports from multiple financial institutions? How do I manage authentication for the database access? Can I do the whole thing serverlessly? After considering all this for a while, I came to thinking that for this a simplest form solution might actually be best. One where I import data manually, don't have to worry about auth because it's all local, and is portable to many other potential personal-data-storage-and-viewing-type applications.</p><br />
     <p >The GitHub repository can be found <a  href="https://github.com/Ulthran/ctbus_finance" target="_blank">here</a>.</p>
@@ -123,5 +133,5 @@ import SimplePage from '../components/SimplePage.vue'
     for a in accounts
     ]
     <p >With that we have our per-account valuation! Next we can create an easy net worth function by summing over the results of the accounts and then subtracting the net CreditCard balance. There are a million other things we might investigate down the line, portfolio distribution over different asset classes, net rate of growth, performance of different investments. But that should all be much easier now that we have this simple infrastructure in place to do it. Another addition to this collection might be a quick Flask site, giving us a quick and dirty method for displaying certain stats and graphs that keeps with the theme of running everything locally. I hope this can be useful for you, it certainly is for me! And remember that this framework can be applied to just about any application you want to build that involves data you want to keep track of and have easy access to!</p>
-  </SimplePage>
+  </v-container>
 </template>

--- a/vue-frontend/src/posts/discovering-prefect.vue
+++ b/vue-frontend/src/posts/discovering-prefect.vue
@@ -1,12 +1,22 @@
 <script setup>
-import SimplePage from '../components/SimplePage.vue'
+import BlogHero from '../components/BlogHero.vue'
+import posts from '../data/posts.js'
+const slug = 'discovering-prefect'
+const info = posts[slug]
 </script>
 
 <template>
-  <SimplePage title="Discovering Prefect">
+  <BlogHero
+    :title="info.title"
+    :subtitle="info.subtitle"
+    :date="info.date"
+    :tags="info.tags"
+    :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
+  />
+  <v-container class="py-4">
     <p >Automation in academia is difficult. Once a protocol is locked down enough to be reasonably automatable, it drifts into being mundane, no longer the cutting edge, and definitely not very publishable. Despite this, primary barriers to faster progress in many data intensive academic research fields are poor data lifecycle management and lack of automated processes. Preprocessing metagenomic sequencing data to make it ready for exploratory analysis can be a complicated task and it's one that takes away hours per project from bioinformaticians who's main value should be added downstream. I was tasked with converting a large array of written preprocessing Standard Operating Procedures into an automation framework to solve this problem for the CHOP Microbiome Center Analytics Core.</p>
     <p >I settled on Airflow as the platform to build on and set about prototyping a solution. But I quickly found that Airflow was significantly overpowered for our needs and I was being forced to provision resources we would have no use for. Additionally the GUI it exposes felt old fashioned and too complex for users just trying to monitor their project's progress. I was about ready to abandon using an automation platform at all and bootstrap a cron-based script monster when I found Prefect and decided to give it a shot.</p>
     <p >Immediately, the experience was different. Getting a prototype up and running on dummy datasets took under a day and deploying a production version that handles only the first protocol followed soon after. The GUI is sleek and immediately provides the information bioinformaticians want when they check it. Implementing a simple interface with SLURM enables Prefect to leverage an internal HPC and achieve throughputs up to tens of terabytes a day (a reasonable upper bound for the sequencing core's output).</p>
     <p >Now that the fun part of standing up the core automation framework is done, we're in the process of finding out all the ways that SOPs need to change in order to be automatable. This ranges from field naming conventions to adjusting access policies to standing up whole new services for achieving metadata standardization. But as more and more of the pipeline comes into production more and more time is repurposed towards downstream analytics and publications. I'd recommend Prefect as the go to platform for any small-to-medium scale automation needs you may have.</p>
-  </SimplePage>
+  </v-container>
 </template>

--- a/vue-frontend/src/posts/disctracker.vue
+++ b/vue-frontend/src/posts/disctracker.vue
@@ -1,9 +1,19 @@
 <script setup>
-import SimplePage from '../components/SimplePage.vue'
+import BlogHero from '../components/BlogHero.vue'
+import posts from '../data/posts.js'
+const slug = 'disctracker'
+const info = posts[slug]
 </script>
 
 <template>
-  <SimplePage title="Ultimate DiscTracker">
+  <BlogHero
+    :title="info.title"
+    :subtitle="info.subtitle"
+    :date="info.date"
+    :tags="info.tags"
+    :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
+  />
+  <v-container class="py-4">
     <p >NOTE: As of writing, this is still very much a work in progress. Don't go to these links expecting polished results (or even a living webpage sometimes).</p>
     <h3 >Inspiration</h3>
     <p >I've seen Moneyball (one of the few Michael Lewis books I actually haven't read though). I know the power of data to uncover non-obvious and non-trivial truths about sports. And with frisbee still being a relatively niche and low budget sport, I think there is a big opportunity to translate existing tools from more established field sports and apply them to frisbee. And I wanted more practice with developing a fullstack web/mobile app so this seemed like the perfect project to undertake.</p>
@@ -17,5 +27,5 @@ import SimplePage from '../components/SimplePage.vue'
     <h3 >Crazy Aspirations</h3>
     <p >One of my pipe dreams when starting this project was to create a platform where a user could speak directly at their phone/tablet over the course of a game and it would parse out relevant "game events" from the dialogue and timestamp them. Despite calling it a pipe dream, I do think that this feature could follow pretty readily for a well built base product. All it would take is access to a voice-to-text module (either built in or accessed through an API) and an LLM with some basic training to recognize "game events". This comes from the number one issue I've heard from users of existing apps for this type of thing: "it's happening too fast and I don't want to look at my phone that much." If instead they could just be narrating the game, that could make it dramatically easier to follow and record the action in a structured format. If any video of the game is also timestamped, it will enable me to sync up any kind of video/analysis pairing features.</p>
     <p >Linking with other services, like Ultiworld for film and relevant articles, USAU for rosters and tournament info, etc. It would take a significant user base and a lot of talking but I am building this with the mindset that it could (keyword, could) be a one stop shop for all things ultimate. I feel like, along with being ambitious, this makes sure that as many doors as possible are open for development down the line.</p>
-  </SimplePage>
+  </v-container>
 </template>

--- a/vue-frontend/src/posts/firewalls-in-china.vue
+++ b/vue-frontend/src/posts/firewalls-in-china.vue
@@ -1,14 +1,24 @@
 <script setup>
-import SimplePage from '../components/SimplePage.vue'
+import BlogHero from '../components/BlogHero.vue'
+import posts from '../data/posts.js'
+const slug = 'firewalls-in-china'
+const info = posts[slug]
 </script>
 
 <template>
-  <SimplePage title="Studying Network Security in China">
+  <BlogHero
+    :title="info.title"
+    :subtitle="info.subtitle"
+    :date="info.date"
+    :tags="info.tags"
+    :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
+  />
+  <v-container class="py-4">
     <p >In the fall of 2019, I spent four months studying Mandarin in Harbin, China with <a href="https://cetacademicprograms.com/college-study-abroad/programs/china/harbin-chinese-language/" target="_blank" >CET</a> and the <a href="http://en.hit.edu.cn/" target="_blank" >Harbin Institute of Technology</a> (HIT). As part of the program, I was able to design a 1-on-1 class with a HIT professor and chose to do it on computer networks and their security (particularly relevant in China, where there is a nationwide firewall preventing access to certain parts of the internet). The end result was a three page paper summarizing the course's content and a number of shorter intermediate papers going into detail on each week's subject.</p>
     <h3 >Why'd You Do This?</h3>
     <p >I had taken Latin for five years previously (7th - 11th grades) but didn't have room for it in my schedule senior year of high school so figured it was time for a change of pace when I got to college. I started taking Chinese and ended up taking a Chinese class for eight of my twelve terms at Carleton (we did trimesters). This includes the fall of Junior year (about half a year before Covid came to the United States) when I did a semester abroad in Harbin, China, which is the northernmost city with a population over five million in China. The program involved developing an independent study type of class, in addition to three other classes, all taught in Chinese and we were only allowed to speak Chinese unless calling our families.</p>
     <h3 >How'd it Go?</h3>
     <p >There's no question that the main challenge of the classes was the language and not the content. Even so, I got a fairly solid overview of the field of network security. I had initially intended to delve more into the Great Firewall itself but I think, especially given the geopolitical climate at the time, my professor astutely avoided that topic. We started by going over relevant concepts of computer networks and some foundational technologies. From there we got into how networks can be segmented and how access can be controlled. This lead into learning about some firewall types, what they protect against, and a little bit of how they can be exploited.</p>
     <p >Despite the lack of technical depth in the course, there were new concepts I was introduced to and for a while afterwards whenever I tried to think or talk about them it would come up in Chinese. Unfortunately at this point it's been a few years since I've spoken or read/written any Chinese and most of it no longer comes naturally. Maybe someday I'll have reason to revive it.</p>
-  </SimplePage>
+  </v-container>
 </template>

--- a/vue-frontend/src/posts/flask-sessions.vue
+++ b/vue-frontend/src/posts/flask-sessions.vue
@@ -1,9 +1,19 @@
 <script setup>
-import SimplePage from '../components/SimplePage.vue'
+import BlogHero from '../components/BlogHero.vue'
+import posts from '../data/posts.js'
+const slug = 'flask-sessions'
+const info = posts[slug]
 </script>
 
 <template>
-  <SimplePage title="Where to Put Flask Session Data">
+  <BlogHero
+    :title="info.title"
+    :subtitle="info.subtitle"
+    :date="info.date"
+    :tags="info.tags"
+    :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
+  />
+  <v-container class="py-4">
     <p >The issue of storing session data on this site came up when I started trying to build a Spotify stats visualizer. The Spotify Web API requires an access token which is retrieved with a combination of the app's API key and the user's login information. The access token then has to be stored somehow so that the user doesn't have to login again everytime the app makes a request. In the case of a web app, it is stored as session data. And as it happens, there are a lot of ways to store session data for a website.</p>
     <h3 >What is Session Data</h3>
     <p >Session data is information that is associated with a particular user of a website and that persists for some amount of time. It can be stored locally on a user's computer, locally on the server running the website, or in a remote database. How it is persisted can also vary to dependent on a timeout, a user action, an administrator action, etc. There are not so minute minutiae I'm skimming here like the difference between session and cookies and more I'm probably not aware of but for this case I was just looking for the simplest way to persist information for a user on my site.</p>
@@ -14,5 +24,5 @@ import SimplePage from '../components/SimplePage.vue'
     <h3 >Third Try: Flask's Built-In <i>session</i> Object</h3>
     <p >Then I realized I had made a signinificant oversight in my initial overview of the options available to me. Flask (without Flask Session) has a built in session object. And that session stores data locally to the user's computer. I tried this way out and it worked immediately. Even better, it incurs no added cost and doesn't add any dependencies to the site (keeping bundle size down). So this is what I went with. And it still gives the ability to have a page where you (the user) can <a href="/session" target="_blank" >view and delete session data</a> from this site.</p><br />
     <p >This was my first foray into using session data on a website. If you have experience with it and want to provide feedback/critique or if you have none and want to know more about my setup, please send me an email. :)</p>
-  </SimplePage>
+  </v-container>
 </template>

--- a/vue-frontend/src/posts/fully-serverless-data-pipeline.vue
+++ b/vue-frontend/src/posts/fully-serverless-data-pipeline.vue
@@ -1,9 +1,19 @@
 <script setup>
-import SimplePage from '../components/SimplePage.vue'
+import BlogHero from '../components/BlogHero.vue'
+import posts from '../data/posts.js'
+const slug = 'fully-serverless-data-pipeline'
+const info = posts[slug]
 </script>
 
 <template>
-  <SimplePage title="A Fully Serverless Data Pipeline">
+  <BlogHero
+    :title="info.title"
+    :subtitle="info.subtitle"
+    :date="info.date"
+    :tags="info.tags"
+    :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
+  />
+  <v-container class="py-4">
     <p >In 2025, I started tracking everything I ingest other than water in a Google doc. I'd already been tracking my weight in a Google spreadsheet and I've worn various different HR trackers for years as well. And now I've earned the Professional AWS DevOps Engineer certification and have a lot of technologies floating around in my head that I want to practice. So I am working on creating an entirely serverless data pipeline for extracting, transforming, ingesting, and viewing all of my health data at once.</p>
     <p >I'm breaking this project down into four logical subdivisions:</p><br />
     <p >1. Extraction: The first step is creating Lambda functions that will access their assigned data sources and provide a recent chunk of the data to an SQS queue</p>
@@ -14,5 +24,5 @@ import SimplePage from '../components/SimplePage.vue'
     <p >1. How much data to extract: We either have to inform the extraction functions with the latest database entry or retrieve more than enough to fill in what's new.</p>
     <p >2. Dead letter queue: To make sure we're not losing data that fails at transform we will want to implement a dead letter queue.</p>
     <p >3. Data visualization: We have a lot of options for this. One is to use Redshift's ZeroETL integration with Aurora but that is almost definitely overpowered for the amount of data we're working with. A likely alternative is custom built serverless dashboards.</p>
-  </SimplePage>
+  </v-container>
 </template>

--- a/vue-frontend/src/posts/multi-dev-deployment.vue
+++ b/vue-frontend/src/posts/multi-dev-deployment.vue
@@ -1,9 +1,19 @@
 <script setup>
-import SimplePage from '../components/SimplePage.vue'
+import BlogHero from '../components/BlogHero.vue'
+import posts from '../data/posts.js'
+const slug = 'multi-dev-deployment'
+const info = posts[slug]
 </script>
 
 <template>
-  <SimplePage title="CI/CD with Feature Environments">
+  <BlogHero
+    :title="info.title"
+    :subtitle="info.subtitle"
+    :date="info.date"
+    :tags="info.tags"
+    :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
+  />
+  <v-container class="py-4">
     <h3 class="text-
     xl font-bold my-4">Intro</h3>
     <i >Some background on the <a  href="">original CI/CD pipeline I created for this site</a> and on the <a  href="">Ultimate Disctracker (UDT)</a> project (which I copied a lot of the CI/CD for) linked here.</i>
@@ -14,5 +24,5 @@ import SimplePage from '../components/SimplePage.vue'
     <p >Once I realized the limitations on that plan, I came back to an earlier solution I had considered. Deploying each dev site to its own subdomain. I had thought that this wasn't feasible for the resources that would have to be set up around each subdomain, but with a little research I found that most of those aren't actually necessary. I modified the CloudFormation script to deploy the site to API Gateway, create a new Custom Domain (in API Gateway), add the root BasePathMapping to my new function, and then add a record to the Route53 Hosted Zone to alias the new subdomain. And what's more, all this can be done with a single certificate that uses <i>*.charliebushman.com</i> as its domain!</p>
     <h3 >Conclusion</h3>
     <p >The end result for me is just removing the occassional dev headache. However, if there were a team of developers working on a site, this would be an absolute essential. Keeping dev deployments from overlapping requires more work but is well worth the siloed testing environments you end up with. And with the CloudFormation script, it's easy to automate the deletion of all those resources when the feature branch is deleted.</p>
-  </SimplePage>
+  </v-container>
 </template>

--- a/vue-frontend/src/posts/qkd.vue
+++ b/vue-frontend/src/posts/qkd.vue
@@ -1,9 +1,19 @@
 <script setup>
-import SimplePage from '../components/SimplePage.vue'
+import BlogHero from '../components/BlogHero.vue'
+import posts from '../data/posts.js'
+const slug = 'qkd'
+const info = posts[slug]
 </script>
 
 <template>
-  <SimplePage title="Quantum Key Distribution">
+  <BlogHero
+    :title="info.title"
+    :subtitle="info.subtitle"
+    :date="info.date"
+    :tags="info.tags"
+    :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
+  />
+  <v-container class="py-4">
     <p >Towards the end of Junior year quantum mechanics we were given an assignment along the lines of go find something cool (quantum mechanics related) and research it and write a short paper on your findings. I picked quantum key distribution (QKD) as my subject because it sounds cool. Turns out, it also is cool. There's a fair amount of groundwork to do to convince others of that though; I'll do my best here, then you can read the paper.</p>
     <h3 >What is This and Why Do We Care?</h3>
     <p >One of the oldest and most widely used cryptographic algorithms is RSA, which uses a public and private key to encrypt and decrypt messages and which relies on the computational complexity of factoring prime numbers for its security. If I want to send you a message using RSA, the steps are fairly straightforward. First, you take two big prime numbers and you multiply them together. The product is your public key and the two starting numbers are your private key (oversimplification). You make your public key public so that I can find it (as can anyone else who might be eavesdropping). Second, I encrypt the super secret file I want to send you with this big number using the RSA algorithm. Then I can send you the encrypted file without worrying about anyone eavesdropping because even if they see what I send, it's just jibberish without the two prime numbers you kept to yourself. You, with the two prime numbers, can use RSA sort of in reverse to decrypt the super secret file.</p>
@@ -14,5 +24,5 @@ import SimplePage from '../components/SimplePage.vue'
     <p >Information theory is a surprisingly recent field that is also surprisingly fundamental. The basic idea behind it is that the information content of anything can be quantified by determining how many bits it would take to represent it. For instance, the number 1000 encodes 10 bits of information because in binary it is 1111101000. The number 1 only has 1 bit of information. But information content is also context dependent. In the context of picking a random number, 127 encodes 7 bits of information because its binary representation is 1111111. However, 1111111 taken as a string, has extremely low entropy -- essentially randomness -- and as such has a low information content. You can easily get into some mind bending situations if you don't keep track of your context as you calculate information content.</p>
     <p >Extending this to quantum information theory, the only thing that changes is the unit, the bit, becomes a quantum bit (qubit). Now instead of a bit encoding either 1 or 0, it is a superposition of the two, which can be represented as a vector of two real (normalized) numbers. So in theory a qubit holds infinitely more information than a bit, though in practice our ability to measure a qubit's exact state without error is severely lacking with current technology. The advantage that this gives quantum computing over classical is that it turns all your logic operations into big matrices that can chug through NP-hard problems very efficiently (problems like cracking RSA).</p>
     <p >There are a couple weird rules with qubits that I feel compelled to cover before letting you go off and read my little paper. The first is that qubits cannot be copied. We know of no physical way in which someone can take a qubit and make an exact copy of it without changing the value of the original. The second is that a qubit can only hold information in one of many bases and when it is measured in a different basis its information content will change. Basically, qubits are very finicky about information access in ways that make the universe work as we know it. Now you're ready, enjoy!</p>
-  </SimplePage>
+  </v-container>
 </template>

--- a/vue-frontend/src/posts/serverless-dashboards-with-dash.vue
+++ b/vue-frontend/src/posts/serverless-dashboards-with-dash.vue
@@ -1,9 +1,19 @@
 <script setup>
-import SimplePage from '../components/SimplePage.vue'
+import BlogHero from '../components/BlogHero.vue'
+import posts from '../data/posts.js'
+const slug = 'serverless-dashboards-with-dash'
+const info = posts[slug]
 </script>
 
 <template>
-  <SimplePage title="Serverless Dashboards with Dash">
+  <BlogHero
+    :title="info.title"
+    :subtitle="info.subtitle"
+    :date="info.date"
+    :tags="info.tags"
+    :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
+  />
+  <v-container class="py-4">
     <p >Up until recently, I had a (janky) Spotify stats visualizer on this site that I had implemented with Flask handling the backend and a simple JavaScript frontend. It wasn't particularly well organized code, especially on the frontend and I wanted to move it to a separate repository. So with the dual goals of trying to offload this bad code and get more practice with AWS SAM, I set about implementing a super simple serverless dashboard.</p><br />
     <p >The finished GitHub repository can be found <a  href="https://github.com/Ulthran/spotify_vis" target="_blank">here</a> and the live site <a  href="https://0qn7o9e6pd.execute-api.us-east-1.amazonaws.com/Prod/" target="_blank">here</a>.</p>
     <p >Going from nothing to having an active serverless data dashboard is a pretty quick process once you know what tools you want to use. In our case, that's the SAM CLI, Dash, Spotipy, and TailwindCSS. Then it's just five steps:</p><br />
@@ -16,5 +26,5 @@ import SimplePage from '../components/SimplePage.vue'
     <p >One piece of the puzzle that I glossed over but is non-trivial is how to define the <i>lambda_handler</i> in <i>app.py</i>. The difference lies in how the app handles custom domains vs API Gateway assigned ones. If you know you'll only use API Gateway assigned domains, you can simplify the event handler. On the bright side, you should be able to just copy/paste what I've written into any project and have it work.</p>
     <p >Unfortunately, Spotify recently removed public access to most of the fun stats they keep on a per-song basis. Things like tempo, key, "danceability," and "speechiness" are now too valuable for training the Recommendation Algorithm to expose, leaving my dashboard with little to show beyond popularity and playtimes. Still, from a technical perspective, there is a major improvement to be made, which you'll probably notice if you visit the site: the initial page load time is super slow. This should be a relatively simple fix, as SAM provides tooling for keeping functions warm!</p><br />
     <p >Expect another blog post soon about a similarly simple serverless data dashboard, this time implemented with Streamlit!</p>
-  </SimplePage>
+  </v-container>
 </template>

--- a/vue-frontend/src/posts/thematic-image-generation.vue
+++ b/vue-frontend/src/posts/thematic-image-generation.vue
@@ -1,9 +1,19 @@
 <script setup>
-import SimplePage from '../components/SimplePage.vue'
+import BlogHero from '../components/BlogHero.vue'
+import posts from '../data/posts.js'
+const slug = 'thematic-image-generation'
+const info = posts[slug]
 </script>
 
 <template>
-  <SimplePage title="Generating Consistent Thematic Images">
+  <BlogHero
+    :title="info.title"
+    :subtitle="info.subtitle"
+    :date="info.date"
+    :tags="info.tags"
+    :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
+  />
+  <v-container class="py-4">
     <p >I recently moved some things around on my site to have this Blog separate from the <a  href="" target="_blank">Projects</a> page. And as part of this move, I wanted to make the Blog look nice by having a little thumbnail art for each post, so I set to work in the AWS Bedrock Playground.</p>
     <p >I had some rough idea of what I wanted the general style of the designs to be, but no good examples. As I started generating images I quickly came to a few realizations. 1) Image generators love putting text from your prompt in the image. You can include negative prompts like "NO WORDS. NO TEXT." but they still resist. 2) If you want a precise style for your output you better be able to describe that style VERY precisely in addition to the content of the image. Any vagueries will allow the model to explore any number of ideas you don't necessarily want. 3) They love generating DNA helixes backwards. Always check your images for reality if that's something that matters to your application.</p>
     <p >By far the best technique for generating the image you want is iterative generation. In the AWS Bedrock Playground it's super easy. Start by prompting it to generate an image and when, most likely, you're disappointed with the results, take the best looking one and select Generate Variation. Then you can modify your prompt, explain changes you want to see, and set it off again. After enough of these iterations, you can actually achieve pretty impressive results.</p>
@@ -16,5 +26,5 @@ import SimplePage from '../components/SimplePage.vue'
     "prompt-strength": 8,
     "similarity-strength": 0.5,
     }
-  </SimplePage>
+  </v-container>
 </template>

--- a/vue-frontend/src/views/BlogList.vue
+++ b/vue-frontend/src/views/BlogList.vue
@@ -5,7 +5,7 @@ const posts = window.posts
 <template>
   <v-container>
     <h1 class="text-h5 font-weight-bold mb-4">Blog</h1>
-    <v-list lines="two">
+    <v-list>
       <v-list-item
         v-for="(post, name) in posts"
         :key="name"
@@ -13,8 +13,8 @@ const posts = window.posts
         link
       >
         <template v-slot:prepend>
-          <v-avatar 
-            class="rounded" 
+          <v-avatar
+            class="rounded"
             :style="{ width: '60px', height: '90px', 'border-radius': '4px' }"
           >
             <v-img :src="`CDN_URL/images/blog/${name.replace(/-/g, '_')}.png`" cover></v-img>
@@ -22,6 +22,20 @@ const posts = window.posts
         </template>
         <v-list-item-title>{{ post.title }}</v-list-item-title>
         <v-list-item-subtitle>{{ post.subtitle }}</v-list-item-subtitle>
+        <v-list-item-subtitle class="text-caption">{{ post.date }}</v-list-item-subtitle>
+        <template v-slot:append>
+          <div class="d-flex flex-wrap">
+            <v-chip
+              v-for="tag in post.tags"
+              :key="tag"
+              class="ma-1"
+              size="x-small"
+              variant="outlined"
+            >
+              {{ tag }}
+            </v-chip>
+          </div>
+        </template>
       </v-list-item>
     </v-list>
   </v-container>

--- a/vue-frontend/src/views/ProjectsList.vue
+++ b/vue-frontend/src/views/ProjectsList.vue
@@ -5,7 +5,7 @@ const projects = window.projects
 <template>
   <v-container>
     <h1 class="text-h5 font-weight-bold mb-4">Projects</h1>
-    <v-list lines="two">
+    <v-list>
       <v-list-item
         v-for="(proj, name) in projects"
         :key="name"
@@ -15,6 +15,19 @@ const projects = window.projects
       >
         <v-list-item-title>{{ proj.title }}</v-list-item-title>
         <v-list-item-subtitle>{{ proj.subtitle }}</v-list-item-subtitle>
+        <template v-slot:append>
+          <div class="d-flex flex-wrap">
+            <v-chip
+              v-for="tag in proj.tags"
+              :key="tag"
+              class="ma-1"
+              size="x-small"
+              variant="outlined"
+            >
+              {{ tag }}
+            </v-chip>
+          </div>
+        </template>
       </v-list-item>
     </v-list>
   </v-container>


### PR DESCRIPTION
## Summary
- add BlogHero component for consistent headers on blog posts
- show post dates and tags in blog list
- show project tags in projects list
- use BlogHero at top of blog post pages

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6863054bf97c832397ca8f1a5d91547e