### PR TITLE
Add component viewer dev tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,19 @@ To deploy the site:
   CloudFront distribution. The CDN will be
   reachable at `https://vue.charliebushman.com`.
 
-To run locally, start a simple web server from the `vue-frontend` directory:
+To run locally, start the helper server which replaces Terraform placeholders:
 
-- `cd vue-frontend && python3 -m http.server`
+- `python3 scripts/serve_vue.py`
+
+The script reads environment variables like `CDN_URL` from a `.env` file if
+present and serves the Vue files with those placeholders replaced.
 
 Then open the given address in your browser.
+
+While running locally, you can quickly debug individual Vue components by
+navigating to `/component/ComponentName`. For example, visiting
+`http://localhost:8000/component/Hero` renders `src/components/Hero.vue` on its
+own page.
 
 Some environment variables are defined in `zappa_settings.json` but others are secret and are defined in a json file uploaded to a bucket defined by `remote_env`. For local deployments, just put everything in a `.env` file.
 

--- a/app/blog.py
+++ b/app/blog.py
@@ -6,7 +6,7 @@ posts = {
         "date": "04/24/25",
         "mod_date": "04/24/25",
         "tags": ["serverless", "aws", "python"],
-        "subtitle": "How \"lambdaliths\" allow for rapid prototyping and at what cost.",
+        "subtitle": 'How "lambdaliths" allow for rapid prototyping and at what cost.',
     },
     "ctbus-finance": {
         "title": "Building a Simple Personal Finance App",

--- a/scripts/serve_vue.py
+++ b/scripts/serve_vue.py
@@ -1,0 +1,72 @@
+import os
+import io
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+def load_env():
+    env_path = Path(__file__).resolve().parent.parent / ".env"
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            if "=" in line and not line.lstrip().startswith("#"):
+                key, val = line.split("=", 1)
+                os.environ.setdefault(key.strip(), val.strip())
+
+
+load_env()
+
+PLACEHOLDERS = {
+    "CDN_URL": os.environ.get("CDN_URL", ""),
+    "SPOTIFY_CLIENT_ID": os.environ.get("SPOTIFY_CLIENT_ID", ""),
+    "SPOTIFY_CLIENT_SECRET": os.environ.get("SPOTIFY_CLIENT_SECRET", ""),
+}
+
+ROOT = Path(__file__).resolve().parent.parent / "vue-frontend"
+
+
+class ReplacingHandler(SimpleHTTPRequestHandler):
+    def translate_path(self, path):
+        path = path.split("?", 1)[0].split("#", 1)[0]
+        return str((ROOT / path.lstrip("/")).resolve())
+
+    def end_headers(self):
+        self.send_header("Cache-Control", "no-store")
+        super().end_headers()
+
+    def send_head(self):
+        path = self.translate_path(self.path)
+        if os.path.isdir(path):
+            for index in ("index.html",):
+                index_path = os.path.join(path, index)
+                if os.path.exists(index_path):
+                    path = index_path
+                    break
+            else:
+                return super().send_head()
+        ctype = self.guess_type(path)
+        try:
+            with open(path, "rb") as f:
+                content = f.read()
+        except OSError:
+            return super().send_head()
+        if ctype.startswith("text/") or ctype == "application/javascript":
+            text = content.decode("utf-8")
+            for key, value in PLACEHOLDERS.items():
+                text = text.replace(key, value)
+            content = text.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-type", ctype)
+        self.send_header("Content-Length", str(len(content)))
+        self.end_headers()
+        return io.BytesIO(content)
+
+
+def main():
+    port = int(os.environ.get("PORT", 8000))
+    server = ThreadingHTTPServer(("", port), ReplacingHandler)
+    print(f"Serving on http://localhost:{port}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/vue-frontend/src/main.js
+++ b/vue-frontend/src/main.js
@@ -47,6 +47,7 @@ const options = {
         { path: '/projects', component: () => window['vue3-sfc-loader'].loadModule(`${window.viewsPath}/ProjectsList.vue`, options) },
         { path: '/projects/:slug', component: () => window['vue3-sfc-loader'].loadModule(`${window.viewsPath}/ProjectDetail.vue`, options) },
         { path: '/resume', component: () => window['vue3-sfc-loader'].loadModule(`${window.viewsPath}/Resume.vue`, options) },
+        { path: '/component/:name', component: () => window['vue3-sfc-loader'].loadModule(`${window.viewsPath}/ComponentViewer.vue`, options) },
         { path: '/sports', component: () => window['vue3-sfc-loader'].loadModule(`${window.viewsPath}/Sports.vue`, options) },
         { path: '/:pathMatch(.*)*', component: () => window['vue3-sfc-loader'].loadModule(`${window.viewsPath}/NotFound.vue`, options) },
       ],

--- a/vue-frontend/src/views/ComponentViewer.vue
+++ b/vue-frontend/src/views/ComponentViewer.vue
@@ -1,0 +1,33 @@
+<script setup>
+import { useRoute } from 'vue-router'
+import { ref, watch } from 'vue'
+
+const route = useRoute()
+const component = ref(null)
+
+async function loadComponent() {
+  const name = route.params.name
+  try {
+    component.value = await window['vue3-sfc-loader'].loadModule(
+      `${window.componentsPath}/${name}.vue`,
+      window.loaderOptions,
+    )
+  } catch (e) {
+    console.error('Failed to load component:', e)
+    component.value = null
+  }
+}
+
+watch(
+  () => route.params.name,
+  () => {
+    loadComponent()
+  },
+  { immediate: true },
+)
+</script>
+
+<template>
+  <component :is="component" v-if="component" />
+  <v-container v-else>Component not found.</v-container>
+</template>


### PR DESCRIPTION
## Summary
- add ComponentViewer.vue for loading individual components by name
- create route at `/component/:name`
- add helper script `serve_vue.py` for local placeholder replacement
- document how to use the viewer and helper server in README

## Testing
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686305709c508323bd17e38c6f5d0854