### PR TITLE
Fix blog post imports to use global posts

### DIFF
--- a/vue-frontend/src/posts/cicd-pipeline.vue
+++ b/vue-frontend/src/posts/cicd-pipeline.vue
@@ -1,6 +1,6 @@
 <script setup>
 import BlogHero from '../components/BlogHero.vue'
-import posts from '../data/posts.js'
+const posts = window.posts
 const slug = 'cicd-pipeline'
 const info = posts[slug]
 </script>

--- a/vue-frontend/src/posts/comps.vue
+++ b/vue-frontend/src/posts/comps.vue
@@ -1,6 +1,6 @@
 <script setup>
 import BlogHero from '../components/BlogHero.vue'
-import posts from '../data/posts.js'
+const posts = window.posts
 const slug = 'comps'
 const info = posts[slug]
 </script>

--- a/vue-frontend/src/posts/discovering-prefect.vue
+++ b/vue-frontend/src/posts/discovering-prefect.vue
@@ -1,6 +1,6 @@
 <script setup>
 import BlogHero from '../components/BlogHero.vue'
-import posts from '../data/posts.js'
+const posts = window.posts
 const slug = 'discovering-prefect'
 const info = posts[slug]
 </script>

--- a/vue-frontend/src/posts/disctracker.vue
+++ b/vue-frontend/src/posts/disctracker.vue
@@ -1,6 +1,6 @@
 <script setup>
 import BlogHero from '../components/BlogHero.vue'
-import posts from '../data/posts.js'
+const posts = window.posts
 const slug = 'disctracker'
 const info = posts[slug]
 </script>

--- a/vue-frontend/src/posts/firewalls-in-china.vue
+++ b/vue-frontend/src/posts/firewalls-in-china.vue
@@ -1,6 +1,6 @@
 <script setup>
 import BlogHero from '../components/BlogHero.vue'
-import posts from '../data/posts.js'
+const posts = window.posts
 const slug = 'firewalls-in-china'
 const info = posts[slug]
 </script>

--- a/vue-frontend/src/posts/flask-sessions.vue
+++ b/vue-frontend/src/posts/flask-sessions.vue
@@ -1,6 +1,6 @@
 <script setup>
 import BlogHero from '../components/BlogHero.vue'
-import posts from '../data/posts.js'
+const posts = window.posts
 const slug = 'flask-sessions'
 const info = posts[slug]
 </script>

--- a/vue-frontend/src/posts/fully-serverless-data-pipeline.vue
+++ b/vue-frontend/src/posts/fully-serverless-data-pipeline.vue
@@ -1,6 +1,6 @@
 <script setup>
 import BlogHero from '../components/BlogHero.vue'
-import posts from '../data/posts.js'
+const posts = window.posts
 const slug = 'fully-serverless-data-pipeline'
 const info = posts[slug]
 </script>

--- a/vue-frontend/src/posts/multi-dev-deployment.vue
+++ b/vue-frontend/src/posts/multi-dev-deployment.vue
@@ -1,6 +1,6 @@
 <script setup>
 import BlogHero from '../components/BlogHero.vue'
-import posts from '../data/posts.js'
+const posts = window.posts
 const slug = 'multi-dev-deployment'
 const info = posts[slug]
 </script>

--- a/vue-frontend/src/posts/qkd.vue
+++ b/vue-frontend/src/posts/qkd.vue
@@ -1,6 +1,6 @@
 <script setup>
 import BlogHero from '../components/BlogHero.vue'
-import posts from '../data/posts.js'
+const posts = window.posts
 const slug = 'qkd'
 const info = posts[slug]
 </script>

--- a/vue-frontend/src/posts/serverless-dashboards-with-dash.vue
+++ b/vue-frontend/src/posts/serverless-dashboards-with-dash.vue
@@ -1,6 +1,6 @@
 <script setup>
 import BlogHero from '../components/BlogHero.vue'
-import posts from '../data/posts.js'
+const posts = window.posts
 const slug = 'serverless-dashboards-with-dash'
 const info = posts[slug]
 </script>

--- a/vue-frontend/src/posts/thematic-image-generation.vue
+++ b/vue-frontend/src/posts/thematic-image-generation.vue
@@ -1,6 +1,6 @@
 <script setup>
 import BlogHero from '../components/BlogHero.vue'
-import posts from '../data/posts.js'
+const posts = window.posts
 const slug = 'thematic-image-generation'
 const info = posts[slug]
 </script>


### PR DESCRIPTION
## Summary
- reference `window.posts` in each blog post component instead of importing posts

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_68630a94cb088323aedaabbc1ffd7fe2