### PR TITLE
Fix resume link behavior

### DIFF
--- a/vue-frontend/src/App.vue
+++ b/vue-frontend/src/App.vue
@@ -9,7 +9,7 @@
         </router-link>
       </v-toolbar-title>
       <v-spacer></v-spacer>
-      <v-btn to="/resume" icon variant="text" router>
+      <v-btn href="CDN_URL/documents/resume.pdf" icon variant="text" target="_blank">
         <v-icon icon="fas fa-file-alt"></v-icon>
       </v-btn>
       <v-btn href="https://github.com/Ulthran" icon variant="text" target="_blank">

--- a/vue-frontend/src/views/Resume.vue
+++ b/vue-frontend/src/views/Resume.vue
@@ -2,7 +2,9 @@
 import { onMounted } from 'vue'
 
 onMounted(() => {
-  window.open('CDN_URL/documents/resume.pdf', '_blank')
+  // Redirect directly to the resume so navigating to /resume
+  // loads the PDF in the current tab instead of opening a new one
+  window.location.replace('CDN_URL/documents/resume.pdf')
 })
 </script>
 


### PR DESCRIPTION
## Summary
- update Resume.vue to redirect to the PDF in the same tab
- change resume button in App.vue to open the PDF directly in a new tab

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686331cc67308323a75a6de6e4275614