### PR TITLE
Improve certificate display

### DIFF
--- a/vue-frontend/src/views/Certifications.vue
+++ b/vue-frontend/src/views/Certifications.vue
@@ -1,72 +1,116 @@
 <script setup>
 import SimplePage from '../components/SimplePage.vue'
+
+const primaryCerts = [
+  {
+    href: 'https://www.credly.com/badges/bcecce87-e9f9-4f05-a068-40eeb7474731/public_url',
+    src: `CDN_URL/certificates/aws_certified_cloud_practitioner.png`,
+    alt: 'AWS Certified Cloud Practitioner - Foundational',
+  },
+  {
+    href: 'https://www.credly.com/badges/a5cc21ee-a95c-4ba8-9a04-9f1f7e4928bf/public_url',
+    src: `CDN_URL/certificates/aws_certified_ai_practitioner_early_adopter.png`,
+    alt: 'AWS Certified AI Practitioner',
+  },
+  {
+    href: 'https://www.credly.com/badges/c6ee2c89-f5d2-46df-826e-b2246435709f/public_url',
+    src: `CDN_URL/certificates/aws_certified_developer_associate.png`,
+    alt: 'AWS Certified Developer - Associate',
+  },
+  {
+    href: 'https://www.credly.com/badges/3decec7b-025c-4f64-a461-01d7d0fd6c22/public_url',
+    src: `CDN_URL/certificates/aws_certified_devops_pro.png`,
+    alt: 'AWS Certified DevOps Engineer - Professional',
+  },
+  {
+    href: 'https://www.credly.com/badges/23e89c9d-02de-49e3-9634-a21816ea29b2/public_url',
+    src: `CDN_URL/certificates/ibm_data_engineering_badge.png`,
+    alt: 'IBM Data Engineering Specialization',
+  },
+]
+
+const extraCerts = {
+  'AWS SkillBuilder': [
+    {
+      href: 'CDN_URL/certificates/aws_security_compliance_governance_for_ai.pdf',
+      title: "Security, Compliance, and Governance for AI Solutions ('25)",
+    },
+    {
+      href: 'CDN_URL/certificates/aws_optimizing_foundation_models.pdf',
+      title: "Optimizing Foudnation Models ('25)",
+    },
+    {
+      href: 'CDN_URL/certificates/aws_essentials_of_prompt_engineering.pdf',
+      title: "Essentials of Prompt Engineering ('25)",
+    },
+    {
+      href: 'CDN_URL/certificates/aws_developing_gen_ai_solutions.pdf',
+      title: "Developing Generative Artificial Intelligence Solutions ('25)",
+    },
+    {
+      href: 'CDN_URL/certificates/aws_developing_ml_solutions.pdf',
+      title: "Developing Machine Learning Solutions ('25)",
+    },
+    {
+      href: 'CDN_URL/certificates/aws_responsible_ai_practices.pdf',
+      title: "Responsible Artificial Intelligence Practices ('25)",
+    },
+    {
+      href: 'CDN_URL/certificates/aws_exploring_ai_use_cases_and_applications.pdf',
+      title: "Exploring Artificial Intelligence Use Cases and Applications ('25)",
+    },
+    {
+      href: 'CDN_URL/certificates/aws_fundamentals_of_ai_and_ml.pdf',
+      title: "Fundamentals of Machine Learning and Artificial Intelligence ('25)",
+    },
+  ],
+  'LinkedIn Learning': [
+    { href: 'CDN_URL/certificates/aws_mls_c01_prep.pdf', title: "AWS Machine Learning ('23)" },
+    { href: 'CDN_URL/certificates/devops_foundations_cicd.pdf', title: "DevOps Foundations: CI/CD ('23)" },
+    { href: 'CDN_URL/certificates/learning_amazon_web_services_for_developers.pdf', title: "Learning AWS for Developers ('23)" },
+    { href: 'CDN_URL/certificates/learning_docker.pdf', title: "Docker ('23)" },
+    { href: 'CDN_URL/certificates/learning_docker_compose.pdf', title: "Docker Compose ('23)" },
+    { href: 'CDN_URL/certificates/25_github_configuration_files_you_should_be_using.pdf', title: "25 GitHub Configuration Files You Should Be Using ('23)" },
+    { href: 'CDN_URL/certificates/scrum_master.pdf', title: "Scrum Master ('23)" },
+    { href: 'CDN_URL/certificates/supporting_allyship_and_antiracism_at_work.pdf', title: "Supporting Allyship and Antiracism at Work ('23)" },
+    { href: 'CDN_URL/certificates/strategic_thinking.pdf', title: "Strategic Thinking ('23)" },
+  ],
+  'Techstrong Learning': [
+    { href: 'CDN_URL/certificates/build_AI_native_foundation.pdf', title: "AI-Native Foundations for Enterprise Apps ('24)" },
+    { href: 'CDN_URL/certificates/future_of_AI_assisted_dev_and_code_qual_cert.pdf', title: "Future of AI Assisted Development and Code Quality ('23)" },
+  ],
+  'Misc and Old': [
+    { href: 'CDN_URL/certificates/IBM_quantum_challenge_fall_2020.pdf', title: "IBM - Quantum Challenge - Foundational ('20)" },
+    { href: 'CDN_URL/certificates/scala_lang_prof.pdf', title: "Lightbend Scala Language - Professional ('20)" },
+    { href: 'https://projecteuler.net/profile/Ulthran.png', title: 'Project Euler (Top 5%)' },
+  ],
+}
 </script>
 
 <template>
   <SimplePage title="Certifications">
-    <a href="https://www.credly.com/badges/bcecce87-e9f9-4f05-a068-40eeb7474731/public_url" target="_blank">
-    <img src="CDN_URL/certificates/aws_certified_cloud_practitioner.png" alt="AWS Certified Cloud Practitioner - Foundational"  height="200px" width="200px" />
-    </a>
-    <a href="https://www.credly.com/badges/a5cc21ee-a95c-4ba8-9a04-9f1f7e4928bf/public_url" target="_blank">
-    <img src="CDN_URL/certificates/aws_certified_ai_practitioner_early_adopter.png" alt="AWS Certified AI Practitioner"  height="240px" width="240px" />
-    </a>
-    <a href="https://www.credly.com/badges/c6ee2c89-f5d2-46df-826e-b2246435709f/public_url" target="_blank">
-    <img src="CDN_URL/certificates/aws_certified_developer_associate.png" alt="AWS Certified Developer - Associate"  height="200px" width="200px" />
-    </a>
-    <a href="https://www.credly.com/badges/3decec7b-025c-4f64-a461-01d7d0fd6c22/public_url" target="_blank">
-    <img src="CDN_URL/certificates/aws_certified_devops_pro.png" alt="AWS Certified DevOps Engineer - Professional"  height="200px" width="200px" />
-    </a>
-    <a href="https://www.credly.com/badges/23e89c9d-02de-49e3-9634-a21816ea29b2/public_url" target="_blank">
-    <img src="CDN_URL/certificates/ibm_data_engineering_badge.png" alt="IBM Data Engineering Specialization"  height="175px" width="175px" />
-    </a>
-    <h2 >Extra Learning and Practice</h2>
-    <h3 >AWS SkillBuilder</h3>
-    <a  href="CDN_URL/certificates/aws_security_compliance_governance_for_ai.pdf" target="_blank" title="Security, Compliance, and Governance for AI Solutions ('25)">
-    </a>
-    <a  href="CDN_URL/certificates/aws_optimizing_foundation_models.pdf" target="_blank" title="Optimizing Foudnation Models ('25)">
-    </a>
-    <a  href="CDN_URL/certificates/aws_essentials_of_prompt_engineering.pdf" target="_blank" title="Essentials of Prompt Engineering ('25)">
-    </a>
-    <a  href="CDN_URL/certificates/aws_developing_gen_ai_solutions.pdf" target="_blank" title="Developing Generative Artificial Intelligence Solutions ('25)">
-    </a>
-    <a  href="CDN_URL/certificates/aws_developing_ml_solutions.pdf" target="_blank" title="Developing Machine Learning Solutions ('25)">
-    </a>
-    <a  href="CDN_URL/certificates/aws_responsible_ai_practices.pdf" target="_blank" title="Responsible Artificial Intelligence Practices ('25)">
-    </a>
-    <a  href="CDN_URL/certificates/aws_exploring_ai_use_cases_and_applications.pdf" target="_blank" title="Exploring Artificial Intelligence Use Cases and Applications ('25)">
-    </a>
-    <a  href="CDN_URL/certificates/aws_fundamentals_of_ai_and_ml.pdf" target="_blank" title="Fundamentals of Machine Learning and Artificial Intelligence ('25)">
-    </a>
-    <h3 >LinkedIn Learning</h3>
-    <a  href="CDN_URL/certificates/aws_mls_c01_prep.pdf" target="_blank" title="AWS Machine Learning ('23)">
-    </a>
-    <a  href="CDN_URL/certificates/devops_foundations_cicd.pdf" target="_blank" title="DevOps Foundations: CI/CD ('23)">
-    </a>
-    <a  href="CDN_URL/certificates/learning_amazon_web_services_for_developers.pdf" target="_blank" title="Learning AWS for Developers ('23)">
-    </a>
-    <a  href="CDN_URL/certificates/learning_docker.pdf" target="_blank" title="Docker ('23)">
-    </a>
-    <a  href="CDN_URL/certificates/learning_docker_compose.pdf" target="_blank" title="Docker Compose ('23)">
-    </a>
-    <a  href="CDN_URL/certificates/25_github_configuration_files_you_should_be_using.pdf" target="_blank" title="25 GitHub Configuration Files You Should Be Using ('23)">
-    </a>
-    <a  href="CDN_URL/certificates/scrum_master.pdf" target="_blank" title="Scrum Master ('23)">
-    </a>
-    <a  href="CDN_URL/certificates/supporting_allyship_and_antiracism_at_work.pdf" target="_blank" title="Supporting Allyship and Antiracism at Work ('23)">
-    </a>
-    <a  href="CDN_URL/certificates/strategic_thinking.pdf" target="_blank" title="Strategic Thinking ('23)">
-    </a>
-    <h3 >Techstrong Learning</h3>
-    <a  href="CDN_URL/certificates/build_AI_native_foundation.pdf" target="_blank" title="AI-Native Foundations for Enterprise Apps ('24)">
-    </a>
-    <a  href="CDN_URL/certificates/future_of_AI_assisted_dev_and_code_qual_cert.pdf" target="_blank" title="Future of AI Assisted Development and Code Quality ('23)">
-    </a>
-    <h3 >Misc and Old</h3>
-    <a  href="CDN_URL/certificates/IBM_quantum_challenge_fall_2020.pdf" target="_blank" title="IBM - Quantum Challenge - Foundational ('20)">
-    </a>
-    <a  href="CDN_URL/certificates/scala_lang_prof.pdf" target="_blank" title="Lightbend Scala Language - Professional ('20)">
-    </a>
-    <a  href="https://projecteuler.net/profile/Ulthran.png" target="_blank" title="Project Euler (Top 5%)">
-    </a>
+    <v-row class="my-4" justify="center" align="center">
+      <v-col cols="auto" v-for="cert in primaryCerts" :key="cert.href">
+        <a :href="cert.href" target="_blank">
+          <v-img :src="cert.src" :alt="cert.alt" height="130" width="130" contain />
+        </a>
+      </v-col>
+    </v-row>
+
+    <h2 class="text-h6 font-weight-bold mt-6">Extra Learning and Practice</h2>
+    <div v-for="(list, name) in extraCerts" :key="name" class="my-4">
+      <h3 class="text-subtitle-1 mb-2">{{ name }}</h3>
+      <div class="d-flex flex-wrap justify-center">
+        <v-chip
+          v-for="cert in list"
+          :key="cert.href"
+          class="ma-1"
+          size="small"
+          variant="outlined"
+        >
+          <a :href="cert.href" target="_blank" class="text-decoration-none">{{ cert.title }}</a>
+        </v-chip>
+      </div>
+    </div>
   </SimplePage>
 </template>

--- a/vue-frontend/src/views/Home.vue
+++ b/vue-frontend/src/views/Home.vue
@@ -6,29 +6,29 @@ const certs = [
     href: 'https://www.credly.com/badges/bcecce87-e9f9-4f05-a068-40eeb7474731/public_url',
     src: `CDN_URL/certificates/aws_certified_cloud_practitioner.png`,
     alt: 'AWS Certified Cloud Practitioner - Foundational',
-    h: 150,
-    w: 150,
+    h: 120,
+    w: 120,
   },
   {
     href: 'https://www.credly.com/badges/a5cc21ee-a95c-4ba8-9a04-9f1f7e4928bf/public_url',
     src: `CDN_URL/certificates/aws_certified_ai_practitioner_early_adopter.png`,
     alt: 'AWS Certified AI Practitioner',
-    h: 180,
-    w: 180,
+    h: 120,
+    w: 120,
   },
   {
     href: 'https://www.credly.com/badges/c6ee2c89-f5d2-46df-826e-b2246435709f/public_url',
     src: `CDN_URL/certificates/aws_certified_developer_associate.png`,
     alt: 'AWS Certified Developer - Associate',
-    h: 150,
-    w: 150,
+    h: 120,
+    w: 120,
   },
   {
     href: 'https://www.credly.com/badges/3decec7b-025c-4f64-a461-01d7d0fd6c22/public_url',
     src: `CDN_URL/certificates/aws_certified_devops_pro.png`,
     alt: 'AWS Certified DevOps Engineer - Professional',
-    h: 150,
-    w: 150,
+    h: 120,
+    w: 120,
   },
 ]
 
@@ -49,7 +49,7 @@ const buttons = [
     title="Charlie Bushman"
     subtitle="Full-Stack Software Engineer with Cloud, DevOps, and Python expertise. Impactful results pushing projects from ideation, to creation, to production. Always eager to learn new technologies, fields, and fun facts."
   >
-    <v-row justify="center" class="my-4">
+    <v-row justify="space-evenly" class="my-4">
       <v-col cols="auto" v-for="cert in certs" :key="cert.href">
         <a :href="cert.href" target="_blank" rel="noopener noreferrer">
           <v-img :src="cert.src" :alt="cert.alt" :height="cert.h" :width="cert.w" contain />


### PR DESCRIPTION
## Summary
- shrink certification badges
- show major cert badges as a row with chips for extras
- decrease badge size on home page and space them evenly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68633137950483239239881d63207004