### PR TITLE
Fix AI Practitioner badge layout

### DIFF
--- a/vue-frontend/src/views/Certifications.vue
+++ b/vue-frontend/src/views/Certifications.vue
@@ -6,26 +6,41 @@ const primaryCerts = [
     href: 'https://www.credly.com/badges/bcecce87-e9f9-4f05-a068-40eeb7474731/public_url',
     src: `CDN_URL/certificates/aws_certified_cloud_practitioner.png`,
     alt: 'AWS Certified Cloud Practitioner - Foundational',
+    h: 130,
+    w: 130,
+    offset: 0,
   },
   {
     href: 'https://www.credly.com/badges/a5cc21ee-a95c-4ba8-9a04-9f1f7e4928bf/public_url',
     src: `CDN_URL/certificates/aws_certified_ai_practitioner_early_adopter.png`,
     alt: 'AWS Certified AI Practitioner',
+    h: 175,
+    w: 175,
+    offset: -30,
   },
   {
     href: 'https://www.credly.com/badges/c6ee2c89-f5d2-46df-826e-b2246435709f/public_url',
     src: `CDN_URL/certificates/aws_certified_developer_associate.png`,
     alt: 'AWS Certified Developer - Associate',
+    h: 130,
+    w: 130,
+    offset: 0,
   },
   {
     href: 'https://www.credly.com/badges/3decec7b-025c-4f64-a461-01d7d0fd6c22/public_url',
     src: `CDN_URL/certificates/aws_certified_devops_pro.png`,
     alt: 'AWS Certified DevOps Engineer - Professional',
+    h: 130,
+    w: 130,
+    offset: 0,
   },
   {
     href: 'https://www.credly.com/badges/23e89c9d-02de-49e3-9634-a21816ea29b2/public_url',
     src: `CDN_URL/certificates/ibm_data_engineering_badge.png`,
     alt: 'IBM Data Engineering Specialization',
+    h: 130,
+    w: 130,
+    offset: 0,
   },
 ]
 
@@ -92,7 +107,14 @@ const extraCerts = {
     <v-row class="my-4" justify="center" align="center">
       <v-col cols="auto" v-for="cert in primaryCerts" :key="cert.href">
         <a :href="cert.href" target="_blank">
-          <v-img :src="cert.src" :alt="cert.alt" height="130" width="130" contain />
+          <v-img
+            :src="cert.src"
+            :alt="cert.alt"
+            :height="cert.h"
+            :width="cert.w"
+            :style="{ marginTop: cert.offset + 'px' }"
+            contain
+          />
         </a>
       </v-col>
     </v-row>

--- a/vue-frontend/src/views/Home.vue
+++ b/vue-frontend/src/views/Home.vue
@@ -8,13 +8,15 @@ const certs = [
     alt: 'AWS Certified Cloud Practitioner - Foundational',
     h: 120,
     w: 120,
+    offset: 0,
   },
   {
     href: 'https://www.credly.com/badges/a5cc21ee-a95c-4ba8-9a04-9f1f7e4928bf/public_url',
     src: `CDN_URL/certificates/aws_certified_ai_practitioner_early_adopter.png`,
     alt: 'AWS Certified AI Practitioner',
-    h: 120,
-    w: 120,
+    h: 175,
+    w: 175,
+    offset: -30,
   },
   {
     href: 'https://www.credly.com/badges/c6ee2c89-f5d2-46df-826e-b2246435709f/public_url',
@@ -22,6 +24,7 @@ const certs = [
     alt: 'AWS Certified Developer - Associate',
     h: 120,
     w: 120,
+    offset: 0,
   },
   {
     href: 'https://www.credly.com/badges/3decec7b-025c-4f64-a461-01d7d0fd6c22/public_url',
@@ -29,6 +32,7 @@ const certs = [
     alt: 'AWS Certified DevOps Engineer - Professional',
     h: 120,
     w: 120,
+    offset: 0,
   },
 ]
 
@@ -52,7 +56,14 @@ const buttons = [
     <v-row justify="space-evenly" class="my-4">
       <v-col cols="auto" v-for="cert in certs" :key="cert.href">
         <a :href="cert.href" target="_blank" rel="noopener noreferrer">
-          <v-img :src="cert.src" :alt="cert.alt" :height="cert.h" :width="cert.w" contain />
+          <v-img
+            :src="cert.src"
+            :alt="cert.alt"
+            :height="cert.h"
+            :width="cert.w"
+            :style="{ marginTop: cert.offset + 'px' }"
+            contain
+          />
         </a>
       </v-col>
     </v-row>


### PR DESCRIPTION
## Summary
- tweak AWS AI Practitioner badge display on Home page and Certifications page
- offset and resize the image so it's consistent with other badges

## Testing
- `terraform init -backend=false` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6863375011288323b9586fd3301f0c81