### PR TITLE
Fix pipeline blog post formatting

### DIFF
--- a/vue-frontend/src/posts/cicd-pipeline.vue
+++ b/vue-frontend/src/posts/cicd-pipeline.vue
@@ -49,7 +49,7 @@ jobs:
         uses: github/super-linter@v4
         env:
           VALIDATE_ALL_CODEBASE: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
           VALIDATE_PYTHON_BLACK: true
           VALIDATE_JAVASCRIPT_ES: true
           FILTER_REGEX_INCLUDE: app/|tests/`


### PR DESCRIPTION
## Summary
- fix YAML snippet escaping in the CI/CD pipeline blog post

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686339c466c08323af534a980659053f