### PR TITLE
Display edited dates for blog posts

### DIFF
--- a/vue-frontend/src/components/BlogHero.vue
+++ b/vue-frontend/src/components/BlogHero.vue
@@ -7,7 +7,10 @@
       <v-col>
         <h1 class="text-h5 font-weight-bold mb-2">{{ title }}</h1>
         <p class="text-subtitle-1 mb-1">{{ subtitle }}</p>
-        <div class="text-caption mb-1">{{ date }}</div>
+        <div class="text-caption mb-1">
+          {{ date }}
+          <span v-if="mod_date !== date">(Edited: {{ mod_date }})</span>
+        </div>
         <div>
           <v-chip
             v-for="tag in tags"
@@ -28,6 +31,7 @@ defineProps({
   title: String,
   subtitle: String,
   date: String,
+  mod_date: String,
   tags: Array,
   img: String,
 });

--- a/vue-frontend/src/posts/cicd-pipeline.vue
+++ b/vue-frontend/src/posts/cicd-pipeline.vue
@@ -343,6 +343,7 @@ const zapYaml = `zap-deployment:
     :title="info.title"
     :subtitle="info.subtitle"
     :date="info.date"
+    :mod_date="info.mod_date"
     :tags="info.tags"
     :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
   />

--- a/vue-frontend/src/posts/comps.vue
+++ b/vue-frontend/src/posts/comps.vue
@@ -10,6 +10,7 @@ const info = posts[slug]
     :title="info.title"
     :subtitle="info.subtitle"
     :date="info.date"
+    :mod_date="info.mod_date"
     :tags="info.tags"
     :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
   />

--- a/vue-frontend/src/posts/ctbus-finance.vue
+++ b/vue-frontend/src/posts/ctbus-finance.vue
@@ -10,6 +10,7 @@ const info = posts[slug]
     :title="info.title"
     :subtitle="info.subtitle"
     :date="info.date"
+    :mod_date="info.mod_date"
     :tags="info.tags"
     :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
   />

--- a/vue-frontend/src/posts/discovering-prefect.vue
+++ b/vue-frontend/src/posts/discovering-prefect.vue
@@ -10,6 +10,7 @@ const info = posts[slug]
     :title="info.title"
     :subtitle="info.subtitle"
     :date="info.date"
+    :mod_date="info.mod_date"
     :tags="info.tags"
     :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
   />

--- a/vue-frontend/src/posts/disctracker.vue
+++ b/vue-frontend/src/posts/disctracker.vue
@@ -10,6 +10,7 @@ const info = posts[slug]
     :title="info.title"
     :subtitle="info.subtitle"
     :date="info.date"
+    :mod_date="info.mod_date"
     :tags="info.tags"
     :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
   />

--- a/vue-frontend/src/posts/firewalls-in-china.vue
+++ b/vue-frontend/src/posts/firewalls-in-china.vue
@@ -10,6 +10,7 @@ const info = posts[slug]
     :title="info.title"
     :subtitle="info.subtitle"
     :date="info.date"
+    :mod_date="info.mod_date"
     :tags="info.tags"
     :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
   />

--- a/vue-frontend/src/posts/flask-sessions.vue
+++ b/vue-frontend/src/posts/flask-sessions.vue
@@ -10,6 +10,7 @@ const info = posts[slug]
     :title="info.title"
     :subtitle="info.subtitle"
     :date="info.date"
+    :mod_date="info.mod_date"
     :tags="info.tags"
     :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
   />

--- a/vue-frontend/src/posts/fully-serverless-data-pipeline.vue
+++ b/vue-frontend/src/posts/fully-serverless-data-pipeline.vue
@@ -10,6 +10,7 @@ const info = posts[slug]
     :title="info.title"
     :subtitle="info.subtitle"
     :date="info.date"
+    :mod_date="info.mod_date"
     :tags="info.tags"
     :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
   />

--- a/vue-frontend/src/posts/multi-dev-deployment.vue
+++ b/vue-frontend/src/posts/multi-dev-deployment.vue
@@ -10,6 +10,7 @@ const info = posts[slug]
     :title="info.title"
     :subtitle="info.subtitle"
     :date="info.date"
+    :mod_date="info.mod_date"
     :tags="info.tags"
     :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
   />

--- a/vue-frontend/src/posts/qkd.vue
+++ b/vue-frontend/src/posts/qkd.vue
@@ -10,6 +10,7 @@ const info = posts[slug]
     :title="info.title"
     :subtitle="info.subtitle"
     :date="info.date"
+    :mod_date="info.mod_date"
     :tags="info.tags"
     :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
   />

--- a/vue-frontend/src/posts/serverless-dashboards-with-dash.vue
+++ b/vue-frontend/src/posts/serverless-dashboards-with-dash.vue
@@ -10,6 +10,7 @@ const info = posts[slug]
     :title="info.title"
     :subtitle="info.subtitle"
     :date="info.date"
+    :mod_date="info.mod_date"
     :tags="info.tags"
     :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
   />

--- a/vue-frontend/src/posts/thematic-image-generation.vue
+++ b/vue-frontend/src/posts/thematic-image-generation.vue
@@ -10,6 +10,7 @@ const info = posts[slug]
     :title="info.title"
     :subtitle="info.subtitle"
     :date="info.date"
+    :mod_date="info.mod_date"
     :tags="info.tags"
     :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
   />

--- a/vue-frontend/src/views/BlogList.vue
+++ b/vue-frontend/src/views/BlogList.vue
@@ -22,7 +22,10 @@ const posts = window.posts
         </template>
         <v-list-item-title>{{ post.title }}</v-list-item-title>
         <v-list-item-subtitle>{{ post.subtitle }}</v-list-item-subtitle>
-        <v-list-item-subtitle class="text-caption">{{ post.date }}</v-list-item-subtitle>
+        <v-list-item-subtitle class="text-caption">
+          {{ post.date }}
+          <span v-if="post.mod_date !== post.date">(Edited: {{ post.mod_date }})</span>
+        </v-list-item-subtitle>
         <v-list-item-subtitle>
           <div class="d-flex flex-wrap">
             <v-chip


### PR DESCRIPTION
## Summary
- allow BlogHero to accept a `mod_date` prop
- show edited date on BlogHero and BlogList when different from creation date
- pass `mod_date` to BlogHero in all posts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68633dac28e083238864c15062683a5f