### PR TITLE
Fix icons on music page

### DIFF
--- a/vue-frontend/src/views/Music.vue
+++ b/vue-frontend/src/views/Music.vue
@@ -79,14 +79,14 @@ onMounted(fetchMonthlyPlaylists)
     title="Music"
     subtitle="Music sounds good. I listen to it a lot and sometimes try to make it. Top 0.05% of Jacob Collier listeners on Spotify for 4 years running. I play piano. I've also made playlists of my new music finds every month since January 2022, follow my Spotify to listen."
   >
-    <div class="d-flex justify-center my-4">
-      <v-btn icon href="https://open.spotify.com/user/charlie_bushman?si=0dd732a8d6da46b6" target="_blank">
-        <v-icon>mdi-spotify</v-icon>
-      </v-btn>
-      <v-btn icon href="https://0qn7o9e6pd.execute-api.us-east-1.amazonaws.com/Prod/" target="_blank">
-        <v-icon>mdi-web</v-icon>
-      </v-btn>
-    </div>
+      <div class="d-flex justify-center my-4">
+        <v-btn icon href="https://open.spotify.com/user/charlie_bushman?si=0dd732a8d6da46b6" target="_blank">
+          <v-icon icon="fa-brands fa-spotify" />
+        </v-btn>
+        <v-btn icon href="https://0qn7o9e6pd.execute-api.us-east-1.amazonaws.com/Prod/" target="_blank">
+          <v-icon icon="fa-solid fa-globe" />
+        </v-btn>
+      </div>
     <div class="d-flex flex-wrap justify-center">
       <div v-for="p in monthlies" :key="p.name" class="text-center ma-2">
         <a :href="p.url" target="_blank" class="text-decoration-none">


### PR DESCRIPTION
## Summary
- replace MDI icons with FontAwesome icons on the Music page

## Testing
- `grep -R "mdi-spotify" -n || true`

------
https://chatgpt.com/codex/tasks/task_e_68633e75eff08323a563ff432ba70999