### PR TITLE
Fix copy icon visibility

### DIFF
--- a/vue-frontend/src/components/CodeBlock.vue
+++ b/vue-frontend/src/components/CodeBlock.vue
@@ -7,6 +7,7 @@
         size="x-small"
         icon="mdi-content-copy"
         variant="text"
+        color="grey lighten-4"
         @click="copyCode"
       ></v-btn>
     </div>


### PR DESCRIPTION
## Summary
- lighten the copy icon in `CodeBlock`

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686341e5ca04832394800f80ae661dc4