### PR TITLE
Add latest post preview in navbar

### DIFF
--- a/vue-frontend/src/App.vue
+++ b/vue-frontend/src/App.vue
@@ -9,6 +9,14 @@
         </router-link>
       </v-toolbar-title>
       <v-spacer></v-spacer>
+      <NavbarPostPreview
+        v-if="latestPost"
+        :link="`/blog/${latestSlug}`"
+        :img="latestImg"
+        :title="latestPost.title"
+        :subtitle="latestPost.subtitle"
+      />
+      <v-spacer></v-spacer>
       <v-btn href="CDN_URL/documents/resume.pdf" icon variant="text" target="_blank">
         <v-icon icon="fas fa-file-alt"></v-icon>
       </v-btn>
@@ -34,11 +42,18 @@
 <script>
 const { computed } = Vue;
 const { useRouter } = VueRouter;
+import NavbarPostPreview from './components/NavbarPostPreview.vue';
 export default {
   name: 'App',
+  components: { NavbarPostPreview },
   setup() {
-    const router = useRouter();
-    return {};
+    const posts = window.posts || {};
+    const latestSlug = Object.keys(posts)[0];
+    const latestPost = latestSlug ? posts[latestSlug] : null;
+    const latestImg = latestSlug
+      ? `CDN_URL/images/blog/${latestSlug.replace(/-/g, '_')}.png`
+      : '';
+    return { latestSlug, latestPost, latestImg };
   },
 };
 </script>

--- a/vue-frontend/src/components/NavbarPostPreview.vue
+++ b/vue-frontend/src/components/NavbarPostPreview.vue
@@ -1,0 +1,18 @@
+<template>
+  <router-link :to="link" class="nav-blog-preview">
+    <v-img :src="img" width="40" height="60" cover class="rounded me-2" />
+    <div class="text-left">
+      <div class="text-body-2">{{ title }}</div>
+      <div class="text-caption">{{ subtitle }}</div>
+    </div>
+  </router-link>
+</template>
+
+<script setup>
+defineProps({
+  link: String,
+  img: String,
+  title: String,
+  subtitle: String,
+});
+</script>

--- a/vue-frontend/src/style.css
+++ b/vue-frontend/src/style.css
@@ -95,3 +95,16 @@ button:focus-visible {
   font-family: 'Fira Code', monospace;
   text-shadow: none;
 }
+
+.nav-blog-preview {
+  display: none;
+  align-items: center;
+  color: inherit;
+  text-decoration: none;
+}
+
+@media (min-width: 960px) {
+  .nav-blog-preview {
+    display: flex;
+  }
+}


### PR DESCRIPTION
## Summary
- create `NavbarPostPreview` component for nav bar blog preview
- show preview of the most recent blog post in the nav bar for wider screens
- style the preview with a media query

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686344f693c883238019964d98582d7d