### PR TITLE
Fix CodeBlock icon visibility

### DIFF
--- a/vue-frontend/src/components/CodeBlock.vue
+++ b/vue-frontend/src/components/CodeBlock.vue
@@ -5,11 +5,12 @@
       <v-btn
         class="copy-btn"
         size="x-small"
-        icon="mdi-content-copy"
         variant="text"
         color="grey lighten-4"
         @click="copyCode"
-      ></v-btn>
+      >
+        <v-icon icon="fas fa-copy" />
+      </v-btn>
     </div>
     <pre ref="pre" class="line-numbers"><code :class="languageClass"></code></pre>
   </v-card>


### PR DESCRIPTION
## Summary
- fix copy button icon visibility by using FontAwesome

## Testing
- `curl -s http://localhost:8000/src/components/CodeBlock.vue | head`

------
https://chatgpt.com/codex/tasks/task_e_6863480c85108323afb55af1f3a657da