### PR TITLE
Improve PCMP page layout

### DIFF
--- a/vue-frontend/src/views/PCMP.vue
+++ b/vue-frontend/src/views/PCMP.vue
@@ -63,26 +63,38 @@ const others = [
   <Hero title="Developer in Statistical Metagenomics with the PCMP" />
 
   <v-container class="text-left">
-    <details class="mb-2">
-      <summary>What is Metagenomics?</summary>
-      <p>If genetics is the study of individual genes and genomics the study of whole genomes, metagenomics looks at collections of genomes. The human gut microbiome, my main focus, is a prime example.</p>
-    </details>
-    <details class="mb-2">
-      <summary>What exactly do you do?</summary>
-      <p>As the software engineer for the PCMP I set development standards, refactor published work, and build internal services ranging from preprocessing automation to compute infrastructure.</p>
-    </details>
-    <details class="mb-2">
-      <summary>What stack do you use?</summary>
-      <p>Python is the language I use most, with R close behind. Pipelines rely on Snakemake and Prefect and run on a mix of HPC and AWS resources. We host code on GitHub and Enterprise GitHub with CI via GitHub Actions.</p>
-    </details>
-    <details class="mb-2">
-      <summary>How do you use ML/AI?</summary>
-      <p>Machine learning tools are integral to many of our analyses and I have begun experimenting with self‑hosted AI agents and knowledge bases to streamline research.</p>
-    </details>
-    <details class="mb-4">
-      <summary>Can I see?</summary>
-      <p>Absolutely! Highlighted projects are below with many more listed for further reading.</p>
-    </details>
+    <h2 class="text-h6 font-weight-bold mb-2">About the PCMP</h2>
+    <p>
+      The Penn‑CHOP Microbiome Program is a joint effort between the Perelman
+      School of Medicine at the University of Pennsylvania and the Children&#39;s
+      Hospital of Philadelphia. The program supports researchers studying the
+      microbiome by providing analysis expertise, open-source tools and
+      compute infrastructure.
+    </p>
+
+    <h2 class="text-h6 font-weight-bold mb-2 mt-6">Human Gut Metagenomics</h2>
+    <p>
+      The human gut contains trillions of microbes. Instead of culturing each
+      one individually, we sequence all DNA from a sample and use computational
+      pipelines to piece together who is there and what they&#39;re doing. These
+      approaches reveal links between the microbiome and health or disease.
+    </p>
+
+    <h2 class="text-h6 font-weight-bold mb-2 mt-6">My Role</h2>
+    <p>
+      As the program&#39;s software engineer I establish development standards,
+      refactor published work and build internal services ranging from
+      preprocessing automation to compute infrastructure.
+    </p>
+
+    <h2 class="text-h6 font-weight-bold mb-2 mt-6">Tech Stack</h2>
+    <ul>
+      <li>Python and R for core analyses</li>
+      <li>Snakemake and Prefect for pipeline orchestration</li>
+      <li>Docker and Conda for reproducible environments</li>
+      <li>HPC and AWS resources for compute</li>
+      <li>GitHub and GitHub Actions for CI/CD</li>
+    </ul>
   </v-container>
 
   <v-container>


### PR DESCRIPTION
## Summary
- enhance the Penn-CHOP Microbiome Program page
- add sections on the program, human gut metagenomics, my role and tech stack

## Testing
- `terraform fmt -check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68634fd48a4c8323a99950e2ed1a003e