### PR TITLE
Add loader for blog posts

### DIFF
--- a/vue-frontend/src/views/BlogPost.vue
+++ b/vue-frontend/src/views/BlogPost.vue
@@ -2,20 +2,31 @@
 import { useRoute } from 'vue-router'
 import { ref, watch } from 'vue'
 
+const loading = ref(true)
+const notFound = ref(false)
+
 const route = useRoute()
 const component = ref(null)
 
 async function loadComponent() {
+  loading.value = true
+  notFound.value = false
+  component.value = null
   const name = route.params.slug
   try {
     component.value = await window['vue3-sfc-loader'].loadModule(
       `${window.postsPath}/${name}.vue`,
       window.loaderOptions,
     )
+    if (!component.value) {
+      notFound.value = true
+    }
   } catch (e) {
     console.error('Error loading component:', e)
     component.value = null
+    notFound.value = true
   }
+  loading.value = false
 }
 
 watch(
@@ -28,6 +39,9 @@ watch(
 </script>
 
 <template>
-  <component :is="component" v-if="component" />
-  <v-container v-else>Post not found.</v-container>
+  <v-container class="py-8 d-flex justify-center" v-if="loading">
+    <v-progress-circular indeterminate />
+  </v-container>
+  <component :is="component" v-else-if="component" />
+  <v-container v-else-if="notFound">Post not found.</v-container>
 </template>

--- a/vue-frontend/src/views/BlogPost.vue
+++ b/vue-frontend/src/views/BlogPost.vue
@@ -25,8 +25,9 @@ async function loadComponent() {
     console.error('Error loading component:', e)
     component.value = null
     notFound.value = true
+  } finally {
+    loading.value = false
   }
-  loading.value = false
 }
 
 watch(

--- a/vue-frontend/src/views/BlogPost.vue
+++ b/vue-frontend/src/views/BlogPost.vue
@@ -41,7 +41,7 @@ watch(
 
 <template>
   <v-container class="py-8 d-flex justify-center" v-if="loading">
-    <v-progress-circular indeterminate />
+    <v-progress-circular indeterminate aria-label="Loading post..." />
   </v-container>
   <component :is="component" v-else-if="component" />
   <v-container v-else-if="notFound">Post not found.</v-container>


### PR DESCRIPTION
## Summary
- add a loading spinner when fetching blog posts
- only show "Post not found" when the fetch fails

## Testing
- `black . --check`

------
https://chatgpt.com/codex/tasks/task_e_6863e97522d4832382181cbef8aa15ab