### PR TITLE
Fix sports page icons

### DIFF
--- a/vue-frontend/src/views/Sports.vue
+++ b/vue-frontend/src/views/Sports.vue
@@ -12,27 +12,27 @@ import Badminton from '../svgs/Badminton.vue'
       <v-row class="py-4" align="center" justify="space-around">
         <v-col cols="auto">
           <a href="https://www.buda.org/en_us/t/mob-3" target="_blank" title="M.O.B.: Hollaredutulliöh">
-            <font-awesome-icon icon="bolt" style="width:48px;height:48px" />
+            <v-icon icon="fas fa-bolt" class="icon-bg" size="48" />
           </a>
         </v-col>
         <v-col cols="auto">
           <a href="https://twitter.com/BruisesUltimate" target="_blank" title="Bruises: Compote ('19)">
-            <font-awesome-icon icon="fist" style="width:48px;height:48px" />
+            <v-icon icon="fas fa-hand-fist" class="icon-bg" size="48" />
           </a>
         </v-col>
         <v-col cols="auto">
           <a href="https://twitter.com/LoS_Ultimate" target="_blank" title="League of Shadows: You either die a hero or live long enough to see yourself become the villain ('21)">
-            <font-awesome-icon icon="bat" style="width:48px;height:48px" />
+            <v-icon icon="fas fa-bat" class="icon-bg" size="48" />
           </a>
         </v-col>
         <v-col cols="auto">
           <a href="https://twitter.com/loco_ultimate" target="_blank" title="Loco: 1. 2. 3. 4. Loco. ('22)">
-            <font-awesome-icon icon="train" style="width:48px;height:48px" />
+            <v-icon icon="fas fa-train" class="icon-bg" size="48" />
           </a>
         </v-col>
         <v-col cols="auto">
           <a href="https://twitter.com/WildCardult" target="_blank" title="Wild Card: Uno, you know ('23)">
-            <font-awesome-icon icon="uno-reverse" style="width:48px;height:48px" />
+            <v-icon icon="fas fa-arrows-rotate" class="icon-bg" size="48" />
           </a>
         </v-col>
       </v-row>
@@ -45,27 +45,27 @@ import Badminton from '../svgs/Badminton.vue'
       <v-row class="py-4" align="center" justify="space-around">
         <v-col cols="auto">
           <a href="https://www.chess.com/member/thwardenheimer" target="_blank" title="My Chess.com profile">
-            <font-awesome-icon icon="chess" style="width:48px;height:48px" />
+            <v-icon icon="fas fa-chess" class="icon-bg" size="48" />
           </a>
         </v-col>
         <v-col cols="auto" class="d-flex flex-column align-center" title="Tactical puzzles are my favorite">
-          <font-awesome-icon icon="puzzle-piece" style="width:24px;height:24px" />
+          <v-icon icon="fas fa-puzzle-piece" class="icon-bg" size="24" />
           <p class="text-body-1 font-weight-bold">{{ chess.tactics }}</p>
         </v-col>
         <v-col cols="auto" class="d-flex flex-column align-center" title="Bullet">
-          <BulletIcon style="width:24px;height:24px" />
+          <v-icon icon="fas fa-bullseye" class="icon-bg" size="24" />
           <p class="text-body-1 font-weight-bold">{{ chess.bullet }}</p>
         </v-col>
         <v-col cols="auto" class="d-flex flex-column align-center" title="Blitz">
-          <font-awesome-icon icon="bolt" style="width:24px;height:24px" />
+          <v-icon icon="fas fa-bolt" class="icon-bg" size="24" />
           <p class="text-body-1 font-weight-bold">{{ chess.blitz }}</p>
         </v-col>
         <v-col cols="auto" class="d-flex flex-column align-center" title="Rapid">
-          <font-awesome-icon icon="stopwatch" style="width:24px;height:24px" />
+          <v-icon icon="fas fa-stopwatch" class="icon-bg" size="24" />
           <p class="text-body-1 font-weight-bold">{{ chess.rapid }}</p>
         </v-col>
         <v-col cols="auto" class="d-flex flex-column align-center" title="Daily">
-          <font-awesome-icon icon="sun" style="width:24px;height:24px" />
+          <v-icon icon="fas fa-sun" class="icon-bg" size="24" />
           <p class="text-body-1 font-weight-bold">{{ chess.daily }}</p>
         </v-col>
       </v-row>
@@ -77,7 +77,7 @@ import Badminton from '../svgs/Badminton.vue'
       <p class="text-body-1">I've skied the northeast my whole life and sometimes go out west just to feel worse about the conditions here.</p>
       <v-row class="py-4" align="center" justify="center">
         <v-col cols="auto">
-          <font-awesome-icon icon="person-skiing" style="width:48px;height:48px" />
+          <v-icon icon="fas fa-person-skiing" class="icon-bg" size="48" />
         </v-col>
       </v-row>
     </v-card>
@@ -88,7 +88,7 @@ import Badminton from '../svgs/Badminton.vue'
       <p class="text-body-1">I played soccer until the end of high school and haven't had the time since. But I was awarded MVP of JV1 and JV2 my freshman year and MVDP (defensive player) of Varsity my senior year.</p>
       <v-row class="py-4" align="center" justify="center">
         <v-col cols="auto">
-          <font-awesome-icon icon="futbol" style="width:48px;height:48px" />
+          <v-icon icon="fas fa-futbol" class="icon-bg" size="48" />
         </v-col>
       </v-row>
     </v-card>
@@ -99,7 +99,9 @@ import Badminton from '../svgs/Badminton.vue'
       <p class="text-body-1">I started playing badminton end of high school and trained 10 hours a week for a few months. Now I play for fun when I can.</p>
       <v-row class="py-4" align="center" justify="center">
         <v-col cols="auto">
-          <font-awesome-icon icon="badminton" style="width:48px;height:48px" />
+          <div class="icon-bg" style="display:inline-block">
+            <Badminton style="width:48px;height:48px" />
+          </div>
         </v-col>
       </v-row>
     </v-card>
@@ -110,9 +112,18 @@ import Badminton from '../svgs/Badminton.vue'
       <p class="text-body-1">I played squash for a few years somewhere around middle school. My crowning achievement was winning the Marblehead YMCA snowflake holiday tournament.</p>
       <v-row class="py-4" align="center" justify="center">
         <v-col cols="auto">
-          <font-awesome-icon icon="squash" style="width:48px;height:48px" />
+          <v-icon icon="fas fa-person-running" class="icon-bg" size="48" />
         </v-col>
       </v-row>
     </v-card>
   </v-container>
 </template>
+
+<style scoped>
+.icon-bg {
+  background-color: #fff;
+  color: #000;
+  border-radius: 4px;
+  padding: 4px;
+}
+</style>


### PR DESCRIPTION
## Summary
- use Vuetify `<v-icon>` so Font Awesome icons render
- add replacement icons for bullet and squash
- wrap custom badminton SVG in icon background
- style all icons with a white background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686401c3f624832396a5105036bd8203