### PR TITLE
Remove unused polyfill

### DIFF
--- a/vue-frontend/index.html
+++ b/vue-frontend/index.html
@@ -18,7 +18,6 @@
         }
       }
     </script>
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6" integrity="sha384-WSLBwI+Q8tqRHaC+f1sjS/FVv5cWp7VAfrGB17HLfZlXhbp5F/RPVP7bYVHtiAWE" crossorigin="anonymous"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" integrity="sha384-Wuix6BuhrWbjDBs24bXrjf4ZQ5aFeFWBuKkFekO2t8xFU0iNaLQfp2K6/1Nxveei" crossorigin="anonymous"></script>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- remove polyfill service script from the Vue template

## Testing
- `terraform -chdir=terraform validate` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864a143aa08832380ed50f89bebe972