### PR TITLE
Improve SEO and highlight resume

### DIFF
--- a/vue-frontend/index.html
+++ b/vue-frontend/index.html
@@ -3,13 +3,48 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" type="image/png" href="CDN_URL/images/favicon.ico" />
-    <title>ctbus</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/vuetify@3.8.10/dist/vuetify.min.css" integrity="sha384-ZoPVozdjzH+jWXpaBM47rBZy9ofMIg8tuIIAsAf5YgJ0wYs5XzytOpaLxiu93Off" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.1/css/all.min.css" integrity="sha384-t1nt8BQoYMLFN5p42tRAtuAAFQaCQODekUVeKKZrEnEyp4H2R0RHFz0KWpmj7i8g" crossorigin="anonymous">
+    <title>Charlie Bushman - Portfolio</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/vuetify@3.8.10/dist/vuetify.min.css"
+      integrity="sha384-ZoPVozdjzH+jWXpaBM47rBZy9ofMIg8tuIIAsAf5YgJ0wYs5XzytOpaLxiu93Off"
+      crossorigin="anonymous"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.1/css/all.min.css"
+      integrity="sha384-t1nt8BQoYMLFN5p42tRAtuAAFQaCQODekUVeKKZrEnEyp4H2R0RHFz0KWpmj7i8g"
+      crossorigin="anonymous"
+    />
     <!--<link rel="stylesheet" href="/src/style.css">-->
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <script src="https://cdn.plot.ly/plotly-2.26.0.min.js" integrity="sha384-xuh4dD2xC9BZ4qOrUrLt8psbgevXF2v+K+FrXxV4MlJHnWKgnaKoh74vd/6Ik8uF" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js" integrity="sha512-vc58qvvBdrDR4etbxMdlTt4GBQk1qjvyORR2nrsPsFPyrs+/u5c3+1Ct6upOgdZoIl7eq6k3a1UPDSNAQi/32A==" crossorigin="anonymous"></script>
+    <meta
+      name="description"
+      content="Portfolio for Charlie Bushman. View resume, explore projects, and read technical blog posts."
+    />
+    <meta
+      name="keywords"
+      content="Charlie Bushman, software engineer, resume, portfolio, projects, blog"
+    />
+    <link rel="canonical" href="https://charliebushman.com/" />
+    <meta property="og:title" content="Charlie Bushman - Software Engineer" />
+    <meta
+      property="og:description"
+      content="Explore Charlie Bushman's resume, projects, and technical blog posts."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://charliebushman.com/" />
+    <meta property="og:image" content="CDN_URL/images/favicon.ico" />
+    <script
+      src="https://cdn.plot.ly/plotly-2.26.0.min.js"
+      integrity="sha384-xuh4dD2xC9BZ4qOrUrLt8psbgevXF2v+K+FrXxV4MlJHnWKgnaKoh74vd/6Ik8uF"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"
+      integrity="sha512-vc58qvvBdrDR4etbxMdlTt4GBQk1qjvyORR2nrsPsFPyrs+/u5c3+1Ct6upOgdZoIl7eq6k3a1UPDSNAQi/32A=="
+      crossorigin="anonymous"
+    ></script>
     <script type="text/x-mathjax-config">
       MathJax = {
         tex: {
@@ -18,17 +53,39 @@
         }
       }
     </script>
-    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" integrity="sha384-Wuix6BuhrWbjDBs24bXrjf4ZQ5aFeFWBuKkFekO2t8xFU0iNaLQfp2K6/1Nxveei" crossorigin="anonymous"></script>
+    <script
+      id="MathJax-script"
+      async
+      src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
+      integrity="sha384-Wuix6BuhrWbjDBs24bXrjf4ZQ5aFeFWBuKkFekO2t8xFU0iNaLQfp2K6/1Nxveei"
+      crossorigin="anonymous"
+    ></script>
   </head>
   <body>
     <div id="app"></div>
-    <script src="https://cdn.jsdelivr.net/npm/vue@3.5.17/dist/vue.global.prod.js" integrity="sha384-H2xBKUDQ/xne/c7DBZjrLhCc6tXYiUu5WAyegWsUsKWMopvozacrKINTNsuJHeFG" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/vue-router@4.5.1/dist/vue-router.global.prod.js" integrity="sha384-FDS5Foi3VsEhWeYrrGBf6c1kcG6lPhi+57Cd57EBDOp5m/Rvl2Sm5n7SKz2q8Sll" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/vuetify@3.8.10/dist/vuetify.min.js" integrity="sha384-urAAOfIFA65yosh73wWyHPAb2WPRsQ6tVB2lLGg3InOxNxvfJAwY4cTkOfsh2Jcf" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/vue3-sfc-loader@0.9.5/dist/vue3-sfc-loader.js" integrity="sha384-PZ/5Vu0PL2YXIi4MMqK0IC4MAQmOqYCJcT1COTIPapsnHFYqN3GW+pQdW7uVFCSm" crossorigin="anonymous"></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/vue@3.5.17/dist/vue.global.prod.js"
+      integrity="sha384-H2xBKUDQ/xne/c7DBZjrLhCc6tXYiUu5WAyegWsUsKWMopvozacrKINTNsuJHeFG"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/vue-router@4.5.1/dist/vue-router.global.prod.js"
+      integrity="sha384-FDS5Foi3VsEhWeYrrGBf6c1kcG6lPhi+57Cd57EBDOp5m/Rvl2Sm5n7SKz2q8Sll"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/vuetify@3.8.10/dist/vuetify.min.js"
+      integrity="sha384-urAAOfIFA65yosh73wWyHPAb2WPRsQ6tVB2lLGg3InOxNxvfJAwY4cTkOfsh2Jcf"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/vue3-sfc-loader@0.9.5/dist/vue3-sfc-loader.js"
+      integrity="sha384-PZ/5Vu0PL2YXIi4MMqK0IC4MAQmOqYCJcT1COTIPapsnHFYqN3GW+pQdW7uVFCSm"
+      crossorigin="anonymous"
+    ></script>
     <script type="module">
-      import posts from '/src/data/posts.js';
-      import projects from '/src/data/projects.js';
+      import posts from "/src/data/posts.js";
+      import projects from "/src/data/projects.js";
       window.posts = posts;
       window.projects = projects;
     </script>

--- a/vue-frontend/src/App.vue
+++ b/vue-frontend/src/App.vue
@@ -2,28 +2,43 @@
   <v-app>
     <v-app-bar class="px-6" color="secondary" dark app>
       <v-toolbar-title class="ml-0 pl-0">
-        <router-link to="/" style="color: inherit; text-decoration: none;">
+        <router-link to="/" style="color: inherit; text-decoration: none">
           <v-btn icon variant="text" router>
             <v-icon aria-label="Home" icon="fas fa-home"></v-icon>
           </v-btn>
         </router-link>
       </v-toolbar-title>
       <v-spacer></v-spacer>
-      <!--<NavbarPostPreview
+      <NavbarPostPreview
         v-if="latestPost"
         :link="`/blog/${latestSlug}`"
         :img="latestImg"
         :title="latestPost.title"
         :subtitle="latestPost.subtitle"
-      />-->
+      />
       <v-spacer></v-spacer>
-      <v-btn href="CDN_URL/documents/resume.pdf" icon variant="text" target="_blank">
+      <v-btn
+        href="CDN_URL/documents/resume.pdf"
+        icon
+        variant="text"
+        target="_blank"
+      >
         <v-icon aria-label="Resume" icon="fas fa-file-alt"></v-icon>
       </v-btn>
-      <v-btn href="https://github.com/Ulthran" icon variant="text" target="_blank">
+      <v-btn
+        href="https://github.com/Ulthran"
+        icon
+        variant="text"
+        target="_blank"
+      >
         <v-icon aria-label="GitHub" icon="fab fa-github"></v-icon>
       </v-btn>
-      <v-btn href="https://www.linkedin.com/in/charlie-bushman-8b0b59128/" icon variant="text" target="_blank">
+      <v-btn
+        href="https://www.linkedin.com/in/charlie-bushman-8b0b59128/"
+        icon
+        variant="text"
+        target="_blank"
+      >
         <v-icon aria-label="LinkedIn" icon="fab fa-linkedin"></v-icon>
       </v-btn>
     </v-app-bar>
@@ -42,17 +57,17 @@
 <script>
 const { computed } = Vue;
 const { useRouter } = VueRouter;
-import NavbarPostPreview from './components/NavbarPostPreview.vue';
+import NavbarPostPreview from "./components/NavbarPostPreview.vue";
 export default {
-  name: 'App',
+  name: "App",
   components: { NavbarPostPreview },
   setup() {
     const posts = window.posts || {};
     const latestSlug = Object.keys(posts)[0];
     const latestPost = latestSlug ? posts[latestSlug] : null;
     const latestImg = latestSlug
-      ? `CDN_URL/images/blog/${latestSlug.replace(/-/g, '_')}.png`
-      : '';
+      ? `CDN_URL/images/blog/${latestSlug.replace(/-/g, "_")}.png`
+      : "";
     return { latestSlug, latestPost, latestImg };
   },
 };

--- a/vue-frontend/src/main.js
+++ b/vue-frontend/src/main.js
@@ -1,59 +1,214 @@
 const options = {
-    moduleCache: {
-      vue: Vue,
-      'vue-router': VueRouter,
-    },
-    async getFile(url) {
-      const res = await fetch(url);
-      if (!res.ok) throw Object.assign(new Error(res.statusText + ' ' + url), { res });
-      return {
-        getContentData: asBinary => asBinary ? res.arrayBuffer() : res.text(),
-      };
-    },
-    addStyle(textContent) {
-      const style = Object.assign(document.createElement('style'), { textContent });
-      const ref = document.head.getElementsByTagName('style')[0] || null;
-      document.head.insertBefore(style, ref);
-    },
-  };
-  window.loaderOptions = options;
-  // use absolute paths so navigation from nested routes works correctly
-  const basePath = '/src';
-  window.basePath = basePath;
-  window.componentsPath = `${basePath}/components`;
-  window.viewsPath = `${basePath}/views`;
-  window.postsPath = `${basePath}/posts`;
-  window.projectsPath = `${basePath}/projects`;
-  window.dataPath = `${basePath}/data`;
-  
-  (async () => {
-    const [App] = await Promise.all([
-      window['vue3-sfc-loader'].loadModule(`${basePath}/App.vue`, options),
-    ]);
-  
-    const router = VueRouter.createRouter({
-      history: VueRouter.createWebHistory(),
-      routes: [
-        { path: '/', component: () => window['vue3-sfc-loader'].loadModule(`${window.viewsPath}/Home.vue`, options) },
-        { path: '/about', component: () => window['vue3-sfc-loader'].loadModule(`${window.viewsPath}/About.vue`, options) },
-        { path: '/blog', component: () => window['vue3-sfc-loader'].loadModule(`${window.viewsPath}/BlogList.vue`, options) },
-        { path: '/blog/:slug', component: () => window['vue3-sfc-loader'].loadModule(`${window.viewsPath}/BlogPost.vue`, options) },
-        { path: '/certifications', component: () => window['vue3-sfc-loader'].loadModule(`${window.viewsPath}/Certifications.vue`, options) },
-        { path: '/education', component: () => window['vue3-sfc-loader'].loadModule(`${window.viewsPath}/Education.vue`, options) },
-        { path: '/favorite-number', component: () => window['vue3-sfc-loader'].loadModule(`${window.viewsPath}/FavoriteNumber.vue`, options) },
-        { path: '/music', component: () => window['vue3-sfc-loader'].loadModule(`${window.viewsPath}/Music.vue`, options) },
-        { path: '/past-work', component: () => window['vue3-sfc-loader'].loadModule(`${window.viewsPath}/PastWork.vue`, options) },
-        { path: '/pcmp', component: () => window['vue3-sfc-loader'].loadModule(`${window.viewsPath}/PCMP.vue`, options) },
-        { path: '/projects', component: () => window['vue3-sfc-loader'].loadModule(`${window.viewsPath}/ProjectsList.vue`, options) },
-        { path: '/projects/:slug', component: () => window['vue3-sfc-loader'].loadModule(`${window.viewsPath}/ProjectDetail.vue`, options) },
-        { path: '/resume', component: () => window['vue3-sfc-loader'].loadModule(`${window.viewsPath}/Resume.vue`, options) },
-        { path: '/sports', component: () => window['vue3-sfc-loader'].loadModule(`${window.viewsPath}/Sports.vue`, options) },
-        { path: '/:pathMatch(.*)*', component: () => window['vue3-sfc-loader'].loadModule(`${window.viewsPath}/NotFound.vue`, options) },
-      ],
+  moduleCache: {
+    vue: Vue,
+    "vue-router": VueRouter,
+  },
+  async getFile(url) {
+    const res = await fetch(url);
+    if (!res.ok)
+      throw Object.assign(new Error(res.statusText + " " + url), { res });
+    return {
+      getContentData: (asBinary) => (asBinary ? res.arrayBuffer() : res.text()),
+    };
+  },
+  addStyle(textContent) {
+    const style = Object.assign(document.createElement("style"), {
+      textContent,
     });
-  
-    const vuetify = Vuetify.createVuetify({
-      /*theme: {
+    const ref = document.head.getElementsByTagName("style")[0] || null;
+    document.head.insertBefore(style, ref);
+  },
+};
+window.loaderOptions = options;
+// use absolute paths so navigation from nested routes works correctly
+const basePath = "/src";
+window.basePath = basePath;
+window.componentsPath = `${basePath}/components`;
+window.viewsPath = `${basePath}/views`;
+window.postsPath = `${basePath}/posts`;
+window.projectsPath = `${basePath}/projects`;
+window.dataPath = `${basePath}/data`;
+
+(async () => {
+  const [App] = await Promise.all([
+    window["vue3-sfc-loader"].loadModule(`${basePath}/App.vue`, options),
+  ]);
+
+  const router = VueRouter.createRouter({
+    history: VueRouter.createWebHistory(),
+    routes: [
+      {
+        path: "/",
+        component: () =>
+          window["vue3-sfc-loader"].loadModule(
+            `${window.viewsPath}/Home.vue`,
+            options,
+          ),
+        meta: {
+          title: "Charlie Bushman - Portfolio",
+          description:
+            "Portfolio for Charlie Bushman showcasing resume, projects and technical blog posts.",
+        },
+      },
+      {
+        path: "/about",
+        component: () =>
+          window["vue3-sfc-loader"].loadModule(
+            `${window.viewsPath}/About.vue`,
+            options,
+          ),
+        meta: { title: "About - Charlie Bushman" },
+      },
+      {
+        path: "/blog",
+        component: () =>
+          window["vue3-sfc-loader"].loadModule(
+            `${window.viewsPath}/BlogList.vue`,
+            options,
+          ),
+        meta: {
+          title: "Blog - Charlie Bushman",
+          description:
+            "Technical articles on software engineering, DevOps and more.",
+        },
+      },
+      {
+        path: "/blog/:slug",
+        component: () =>
+          window["vue3-sfc-loader"].loadModule(
+            `${window.viewsPath}/BlogPost.vue`,
+            options,
+          ),
+        meta: { title: "Blog Post - Charlie Bushman" },
+      },
+      {
+        path: "/certifications",
+        component: () =>
+          window["vue3-sfc-loader"].loadModule(
+            `${window.viewsPath}/Certifications.vue`,
+            options,
+          ),
+        meta: { title: "Certifications - Charlie Bushman" },
+      },
+      {
+        path: "/education",
+        component: () =>
+          window["vue3-sfc-loader"].loadModule(
+            `${window.viewsPath}/Education.vue`,
+            options,
+          ),
+        meta: { title: "Education - Charlie Bushman" },
+      },
+      {
+        path: "/favorite-number",
+        component: () =>
+          window["vue3-sfc-loader"].loadModule(
+            `${window.viewsPath}/FavoriteNumber.vue`,
+            options,
+          ),
+        meta: { title: "Favorite Number - Charlie Bushman" },
+      },
+      {
+        path: "/music",
+        component: () =>
+          window["vue3-sfc-loader"].loadModule(
+            `${window.viewsPath}/Music.vue`,
+            options,
+          ),
+        meta: { title: "Music - Charlie Bushman" },
+      },
+      {
+        path: "/past-work",
+        component: () =>
+          window["vue3-sfc-loader"].loadModule(
+            `${window.viewsPath}/PastWork.vue`,
+            options,
+          ),
+        meta: { title: "Past Work - Charlie Bushman" },
+      },
+      {
+        path: "/pcmp",
+        component: () =>
+          window["vue3-sfc-loader"].loadModule(
+            `${window.viewsPath}/PCMP.vue`,
+            options,
+          ),
+        meta: { title: "Work - Charlie Bushman" },
+      },
+      {
+        path: "/projects",
+        component: () =>
+          window["vue3-sfc-loader"].loadModule(
+            `${window.viewsPath}/ProjectsList.vue`,
+            options,
+          ),
+        meta: {
+          title: "Projects - Charlie Bushman",
+          description:
+            "Explore projects designed and built by Charlie Bushman.",
+        },
+      },
+      {
+        path: "/projects/:slug",
+        component: () =>
+          window["vue3-sfc-loader"].loadModule(
+            `${window.viewsPath}/ProjectDetail.vue`,
+            options,
+          ),
+        meta: { title: "Project Details - Charlie Bushman" },
+      },
+      {
+        path: "/resume",
+        component: () =>
+          window["vue3-sfc-loader"].loadModule(
+            `${window.viewsPath}/Resume.vue`,
+            options,
+          ),
+        meta: {
+          title: "Resume - Charlie Bushman",
+          description: "Download the resume of Charlie Bushman.",
+        },
+      },
+      {
+        path: "/sports",
+        component: () =>
+          window["vue3-sfc-loader"].loadModule(
+            `${window.viewsPath}/Sports.vue`,
+            options,
+          ),
+        meta: { title: "Sports - Charlie Bushman" },
+      },
+      {
+        path: "/:pathMatch(.*)*",
+        component: () =>
+          window["vue3-sfc-loader"].loadModule(
+            `${window.viewsPath}/NotFound.vue`,
+            options,
+          ),
+        meta: { title: "Not Found - Charlie Bushman" },
+      },
+    ],
+  });
+
+  router.afterEach((to) => {
+    const defaultTitle = "Charlie Bushman - Portfolio";
+    const defaultDescription =
+      "Portfolio for Charlie Bushman showcasing resume, projects and technical blog posts.";
+    document.title = to.meta.title || defaultTitle;
+    const desc = to.meta.description || defaultDescription;
+    let meta = document.querySelector("meta[name='description']");
+    if (meta) {
+      meta.setAttribute("content", desc);
+    } else {
+      meta = document.createElement("meta");
+      meta.name = "description";
+      meta.content = desc;
+      document.head.appendChild(meta);
+    }
+  });
+
+  const vuetify = Vuetify.createVuetify({
+    /*theme: {
         defaultTheme: 'dark',
         themes: {
             dark: {
@@ -66,7 +221,7 @@ const options = {
             },
         },
       },*/
-    });
-  
-    Vue.createApp(App).use(router).use(vuetify).mount('#app');
-  })();
+  });
+
+  Vue.createApp(App).use(router).use(vuetify).mount("#app");
+})();

--- a/vue-frontend/src/views/Home.vue
+++ b/vue-frontend/src/views/Home.vue
@@ -72,7 +72,7 @@ const buttons = [
     </v-row>
     <v-row justify="center" class="mb-4">
       <router-link to="/resume">
-        <v-btn color="green-darken-2" variant="elevated">View Resume</v-btn>
+        <v-btn color="green-darken-2" variant="elevated" aria-label="View Charlie Bushman's resume">View Resume</v-btn>
       </router-link>
     </v-row>
   </Hero>

--- a/vue-frontend/src/views/Home.vue
+++ b/vue-frontend/src/views/Home.vue
@@ -1,52 +1,53 @@
 <script setup>
-import Hero from '../components/Hero.vue'
-import Frisbee from '../svgs/Frisbee.vue'
+import Hero from "../components/Hero.vue";
+import Frisbee from "../svgs/Frisbee.vue";
 
 const certs = [
   {
-    href: 'https://www.credly.com/badges/bcecce87-e9f9-4f05-a068-40eeb7474731/public_url',
+    href: "https://www.credly.com/badges/bcecce87-e9f9-4f05-a068-40eeb7474731/public_url",
     src: `CDN_URL/certificates/aws_certified_cloud_practitioner.png`,
-    alt: 'AWS Certified Cloud Practitioner - Foundational',
+    alt: "AWS Certified Cloud Practitioner - Foundational",
     h: 120,
     w: 120,
     offset: 0,
   },
   {
-    href: 'https://www.credly.com/badges/a5cc21ee-a95c-4ba8-9a04-9f1f7e4928bf/public_url',
+    href: "https://www.credly.com/badges/a5cc21ee-a95c-4ba8-9a04-9f1f7e4928bf/public_url",
     src: `CDN_URL/certificates/aws_certified_ai_practitioner_early_adopter.png`,
-    alt: 'AWS Certified AI Practitioner',
+    alt: "AWS Certified AI Practitioner",
     h: 205,
     w: 205,
     offset: -25,
   },
   {
-    href: 'https://www.credly.com/badges/c6ee2c89-f5d2-46df-826e-b2246435709f/public_url',
+    href: "https://www.credly.com/badges/c6ee2c89-f5d2-46df-826e-b2246435709f/public_url",
     src: `CDN_URL/certificates/aws_certified_developer_associate.png`,
-    alt: 'AWS Certified Developer - Associate',
+    alt: "AWS Certified Developer - Associate",
     h: 120,
     w: 120,
     offset: 0,
   },
   {
-    href: 'https://www.credly.com/badges/3decec7b-025c-4f64-a461-01d7d0fd6c22/public_url',
+    href: "https://www.credly.com/badges/3decec7b-025c-4f64-a461-01d7d0fd6c22/public_url",
     src: `CDN_URL/certificates/aws_certified_devops_pro.png`,
-    alt: 'AWS Certified DevOps Engineer - Professional',
+    alt: "AWS Certified DevOps Engineer - Professional",
     h: 120,
     w: 120,
     offset: 0,
   },
-]
+];
 
 const buttons = [
-  { to: '/pcmp', label: 'Work', icon: 'fas fa-briefcase' },
-  { to: '/blog', label: 'Blog', icon: 'fas fa-code' },
-  { to: '/projects', label: 'Projects', icon: 'fas fa-project-diagram' },
-  { to: '/certifications', label: 'Certs', icon: 'fas fa-certificate' },
-  { to: '/education', label: 'Education', icon: 'fas fa-graduation-cap' },
-  { to: '/past-work', label: 'Past Work', icon: 'fas fa-history' },
-  { to: '/sports', label: 'Sports', icon: 'fas fa-futbol' },
-  { to: '/music', label: 'Music', icon: 'fas fa-music' },
-]
+  { to: "/resume", label: "Resume", icon: "fas fa-file-alt" },
+  { to: "/projects", label: "Projects", icon: "fas fa-project-diagram" },
+  { to: "/blog", label: "Blog", icon: "fas fa-code" },
+  { to: "/pcmp", label: "Work", icon: "fas fa-briefcase" },
+  { to: "/certifications", label: "Certs", icon: "fas fa-certificate" },
+  { to: "/education", label: "Education", icon: "fas fa-graduation-cap" },
+  { to: "/past-work", label: "Past Work", icon: "fas fa-history" },
+  { to: "/sports", label: "Sports", icon: "fas fa-futbol" },
+  { to: "/music", label: "Music", icon: "fas fa-music" },
+];
 </script>
 
 <template>
@@ -69,6 +70,11 @@ const buttons = [
         </a>
       </v-col>
     </v-row>
+    <v-row justify="center" class="mb-4">
+      <router-link to="/resume">
+        <v-btn color="green-darken-2" variant="elevated">View Resume</v-btn>
+      </router-link>
+    </v-row>
   </Hero>
 
   <v-container class="text-center">
@@ -78,7 +84,12 @@ const buttons = [
           <v-btn color="green-darken-2" class="ma-2" variant="elevated">
             {{ btn.label }}
             <span class="ms-2">
-              <component v-if="btn.component" :is="btn.component" :size="16" :mode=light />
+              <component
+                v-if="btn.component"
+                :is="btn.component"
+                :size="16"
+                :mode="light"
+              />
               <i v-else :class="btn.icon"></i>
             </span>
           </v-btn>


### PR DESCRIPTION
## Summary
- add meta tags and OG data to help search engines
- show resume button prominently on home page and allow quick access
- display latest blog post in the navbar
- update vue router to manage page titles and descriptions dynamically

## Testing
- `npx prettier -w vue-frontend/index.html vue-frontend/src/views/Home.vue vue-frontend/src/App.vue vue-frontend/src/main.js`
- `terraform validate` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6869d6e258d0832381c28bbb7d121fd2