### PR TITLE
Add Prettier configuration and clean nav bar

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,8 @@ jobs:
           npm install -g prettier
 
       - name: Prettier Check
-        run: prettier --check "vue-frontend/**/*.{js,vue,css,html}"
+        run: |
+          prettier --config .prettierrc.json --check "vue-frontend/**/*.{js,vue,css,html}" "terraform/**/*.js"
 
       - name: Terraform Format
         run: terraform fmt -check -recursive

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "semi": true
+}

--- a/terraform/spa-redirect.js
+++ b/terraform/spa-redirect.js
@@ -1,8 +1,8 @@
 function handler(event) {
   var request = event.request;
   var uri = request.uri;
-  if (!uri.includes('.')) {
-    request.uri = '/index.html';
+  if (!uri.includes(".")) {
+    request.uri = "/index.html";
   }
   return request;
 }

--- a/vue-frontend/src/App.vue
+++ b/vue-frontend/src/App.vue
@@ -9,14 +9,6 @@
         </router-link>
       </v-toolbar-title>
       <v-spacer></v-spacer>
-      <NavbarPostPreview
-        v-if="latestPost"
-        :link="`/blog/${latestSlug}`"
-        :img="latestImg"
-        :title="latestPost.title"
-        :subtitle="latestPost.subtitle"
-      />
-      <v-spacer></v-spacer>
       <v-btn
         href="CDN_URL/documents/resume.pdf"
         icon
@@ -55,20 +47,5 @@
 </template>
 
 <script>
-const { computed } = Vue;
-const { useRouter } = VueRouter;
-import NavbarPostPreview from "./components/NavbarPostPreview.vue";
-export default {
-  name: "App",
-  components: { NavbarPostPreview },
-  setup() {
-    const posts = window.posts || {};
-    const latestSlug = Object.keys(posts)[0];
-    const latestPost = latestSlug ? posts[latestSlug] : null;
-    const latestImg = latestSlug
-      ? `CDN_URL/images/blog/${latestSlug.replace(/-/g, "_")}.png`
-      : "";
-    return { latestSlug, latestPost, latestImg };
-  },
-};
+export default { name: "App" };
 </script>

--- a/vue-frontend/src/main.js
+++ b/vue-frontend/src/main.js
@@ -42,7 +42,7 @@ window.dataPath = `${basePath}/data`;
         component: () =>
           window["vue3-sfc-loader"].loadModule(
             `${window.viewsPath}/Home.vue`,
-            options,
+            options
           ),
         meta: {
           title: "Charlie Bushman - Portfolio",
@@ -55,7 +55,7 @@ window.dataPath = `${basePath}/data`;
         component: () =>
           window["vue3-sfc-loader"].loadModule(
             `${window.viewsPath}/About.vue`,
-            options,
+            options
           ),
         meta: { title: "About - Charlie Bushman" },
       },
@@ -64,7 +64,7 @@ window.dataPath = `${basePath}/data`;
         component: () =>
           window["vue3-sfc-loader"].loadModule(
             `${window.viewsPath}/BlogList.vue`,
-            options,
+            options
           ),
         meta: {
           title: "Blog - Charlie Bushman",
@@ -77,7 +77,7 @@ window.dataPath = `${basePath}/data`;
         component: () =>
           window["vue3-sfc-loader"].loadModule(
             `${window.viewsPath}/BlogPost.vue`,
-            options,
+            options
           ),
         meta: { title: "Blog Post - Charlie Bushman" },
       },
@@ -86,7 +86,7 @@ window.dataPath = `${basePath}/data`;
         component: () =>
           window["vue3-sfc-loader"].loadModule(
             `${window.viewsPath}/Certifications.vue`,
-            options,
+            options
           ),
         meta: { title: "Certifications - Charlie Bushman" },
       },
@@ -95,7 +95,7 @@ window.dataPath = `${basePath}/data`;
         component: () =>
           window["vue3-sfc-loader"].loadModule(
             `${window.viewsPath}/Education.vue`,
-            options,
+            options
           ),
         meta: { title: "Education - Charlie Bushman" },
       },
@@ -104,7 +104,7 @@ window.dataPath = `${basePath}/data`;
         component: () =>
           window["vue3-sfc-loader"].loadModule(
             `${window.viewsPath}/FavoriteNumber.vue`,
-            options,
+            options
           ),
         meta: { title: "Favorite Number - Charlie Bushman" },
       },
@@ -113,7 +113,7 @@ window.dataPath = `${basePath}/data`;
         component: () =>
           window["vue3-sfc-loader"].loadModule(
             `${window.viewsPath}/Music.vue`,
-            options,
+            options
           ),
         meta: { title: "Music - Charlie Bushman" },
       },
@@ -122,7 +122,7 @@ window.dataPath = `${basePath}/data`;
         component: () =>
           window["vue3-sfc-loader"].loadModule(
             `${window.viewsPath}/PastWork.vue`,
-            options,
+            options
           ),
         meta: { title: "Past Work - Charlie Bushman" },
       },
@@ -131,7 +131,7 @@ window.dataPath = `${basePath}/data`;
         component: () =>
           window["vue3-sfc-loader"].loadModule(
             `${window.viewsPath}/PCMP.vue`,
-            options,
+            options
           ),
         meta: { title: "Work - Charlie Bushman" },
       },
@@ -140,7 +140,7 @@ window.dataPath = `${basePath}/data`;
         component: () =>
           window["vue3-sfc-loader"].loadModule(
             `${window.viewsPath}/ProjectsList.vue`,
-            options,
+            options
           ),
         meta: {
           title: "Projects - Charlie Bushman",
@@ -153,7 +153,7 @@ window.dataPath = `${basePath}/data`;
         component: () =>
           window["vue3-sfc-loader"].loadModule(
             `${window.viewsPath}/ProjectDetail.vue`,
-            options,
+            options
           ),
         meta: { title: "Project Details - Charlie Bushman" },
       },
@@ -162,7 +162,7 @@ window.dataPath = `${basePath}/data`;
         component: () =>
           window["vue3-sfc-loader"].loadModule(
             `${window.viewsPath}/Resume.vue`,
-            options,
+            options
           ),
         meta: {
           title: "Resume - Charlie Bushman",
@@ -174,7 +174,7 @@ window.dataPath = `${basePath}/data`;
         component: () =>
           window["vue3-sfc-loader"].loadModule(
             `${window.viewsPath}/Sports.vue`,
-            options,
+            options
           ),
         meta: { title: "Sports - Charlie Bushman" },
       },
@@ -183,7 +183,7 @@ window.dataPath = `${basePath}/data`;
         component: () =>
           window["vue3-sfc-loader"].loadModule(
             `${window.viewsPath}/NotFound.vue`,
-            options,
+            options
           ),
         meta: { title: "Not Found - Charlie Bushman" },
       },

--- a/vue-frontend/src/posts/comps.vue
+++ b/vue-frontend/src/posts/comps.vue
@@ -95,7 +95,7 @@ onMounted(() => {
         paper_bgcolor: "#F3F4F6",
         showlegend: false,
       },
-      { responsive: true },
+      { responsive: true }
     );
   }
 
@@ -103,7 +103,7 @@ onMounted(() => {
     "Lorenz_unlinked_2",
     system3.x,
     system3.z,
-    "Unlinked Lorenz Attractor #2",
+    "Unlinked Lorenz Attractor #2"
   );
   plot("Lorenz", system1.x, system1.z, "Lorenz Attractor #1");
   plot("Lorenz2", system2.x, system2.z, "Linked Lorenz Attractor #2");
@@ -150,7 +150,7 @@ onMounted(() => {
             { x: system3.x.slice(1), y: system3.z.slice(1) },
           ],
         },
-        { transition: { duration: 0 }, frame: { duration: 0, redraw: false } },
+        { transition: { duration: 0 }, frame: { duration: 0, redraw: false } }
       );
 
       Plotly.animate(
@@ -161,7 +161,7 @@ onMounted(() => {
             { x: system1.x.slice(1), y: system1.z.slice(1) },
           ],
         },
-        { transition: { duration: 0 }, frame: { duration: 0, redraw: false } },
+        { transition: { duration: 0 }, frame: { duration: 0, redraw: false } }
       );
 
       Plotly.animate(
@@ -172,7 +172,7 @@ onMounted(() => {
             { x: system2.x.slice(1), y: system2.z.slice(1) },
           ],
         },
-        { transition: { duration: 0 }, frame: { duration: 0, redraw: false } },
+        { transition: { duration: 0 }, frame: { duration: 0, redraw: false } }
       );
     }
 
@@ -228,7 +228,7 @@ onMounted(() => {
         zaxis: { range: [-5, 5], showticklabels: false, zeroline: false },
         plot_bgcolor: "#F3F4F6",
         paper_bgcolor: "#F3F4F6",
-      },
+      }
     );
   });
 

--- a/vue-frontend/src/style.css
+++ b/vue-frontend/src/style.css
@@ -92,21 +92,8 @@ button:focus-visible {
   overflow-x: auto;
 }
 .blog-content code {
-  font-family: 'Fira Code', monospace;
+  font-family: "Fira Code", monospace;
   text-shadow: none;
-}
-
-.nav-blog-preview {
-  display: none;
-  align-items: center;
-  color: inherit;
-  text-decoration: none;
-}
-
-@media (min-width: 960px) {
-  .nav-blog-preview {
-    display: flex;
-  }
 }
 
 .flip-card {

--- a/vue-frontend/src/svgs/Batman.vue
+++ b/vue-frontend/src/svgs/Batman.vue
@@ -35,6 +35,6 @@ const props = defineProps({
 });
 const color = computed(() => (props.mode === "light" ? "#fff" : "#000"));
 const secondaryColor = computed(() =>
-  props.mode === "light" ? "#000" : "#fff",
+  props.mode === "light" ? "#000" : "#fff"
 );
 </script>

--- a/vue-frontend/src/views/BlogPost.vue
+++ b/vue-frontend/src/views/BlogPost.vue
@@ -16,7 +16,7 @@ async function loadComponent() {
   try {
     component.value = await window["vue3-sfc-loader"].loadModule(
       `${window.postsPath}/${name}.vue`,
-      window.loaderOptions,
+      window.loaderOptions
     );
     if (!component.value) {
       notFound.value = true;
@@ -35,7 +35,7 @@ watch(
   () => {
     loadComponent();
   },
-  { immediate: true },
+  { immediate: true }
 );
 </script>
 

--- a/vue-frontend/src/views/Home.vue
+++ b/vue-frontend/src/views/Home.vue
@@ -72,7 +72,12 @@ const buttons = [
     </v-row>
     <v-row justify="center" class="mb-4">
       <router-link to="/resume">
-        <v-btn color="green-darken-2" variant="elevated" aria-label="View Charlie Bushman's resume">View Resume</v-btn>
+        <v-btn
+          color="green-darken-2"
+          variant="elevated"
+          aria-label="View Charlie Bushman's resume"
+          >View Resume</v-btn
+        >
       </router-link>
     </v-row>
   </Hero>

--- a/vue-frontend/src/views/ProjectDetail.vue
+++ b/vue-frontend/src/views/ProjectDetail.vue
@@ -10,7 +10,7 @@ async function loadComponent() {
   try {
     component.value = await window["vue3-sfc-loader"].loadModule(
       `${window.projectsPath}/${name}.vue`,
-      window.loaderOptions,
+      window.loaderOptions
     );
   } catch (e) {
     console.error("Failed to load component:", e);
@@ -23,7 +23,7 @@ watch(
   () => {
     loadComponent();
   },
-  { immediate: true },
+  { immediate: true }
 );
 </script>
 


### PR DESCRIPTION
## Summary
- add `.prettierrc.json` to control code formatting
- reference this config in the workflow
- reformat existing files with Prettier
- remove blog post preview from navigation bar

## Testing
- `npx prettier --check "vue-frontend/**/*.{js,vue,css,html}" "terraform/**/*.js"`
- `terraform -chdir=terraform init -backend=false` *(fails: command not found)*
- `terraform -chdir=terraform validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869e4ba630c832386fa04d324541a34