### PR TITLE
Add skeleton for AI root cause post

### DIFF
--- a/vue-frontend/src/data/posts.js
+++ b/vue-frontend/src/data/posts.js
@@ -1,4 +1,11 @@
 export default {
+  "ai-root-cause-analysis-in-sunbeam": {
+    title: "AI Root Cause Analysis in Sunbeam",
+    date: "05/12/25",
+    mod_date: "05/12/25",
+    tags: ["ai", "sunbeam", "debugging"],
+    subtitle: "Launching automated debugging with AI assistance in Sunbeam.",
+  },
   "ctbus-finance": {
     title: "Building a Simple Personal Finance App",
     date: "04/07/25",

--- a/vue-frontend/src/posts/ai-root-cause-analysis-in-sunbeam.vue
+++ b/vue-frontend/src/posts/ai-root-cause-analysis-in-sunbeam.vue
@@ -1,0 +1,22 @@
+<script setup>
+import BlogHero from "../components/BlogHero.vue";
+import Paragraph from "../components/Paragraph.vue";
+import SectionTitle from "../components/SectionTitle.vue";
+const posts = window.posts;
+const slug = "ai-root-cause-analysis-in-sunbeam";
+const info = posts[slug];
+</script>
+
+<template>
+  <BlogHero
+    :title="info.title"
+    :subtitle="info.subtitle"
+    :date="info.date"
+    :mod_date="info.mod_date"
+    :tags="info.tags"
+    :img="`CDN_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
+  />
+  <v-container class="py-4 blog-content">
+    <Paragraph> Post content coming soon. </Paragraph>
+  </v-container>
+</template>


### PR DESCRIPTION
## Summary
- create placeholder post: *AI Root Cause Analysis in Sunbeam*
- register new post in the posts metadata

## Testing
- `npx prettier -w vue-frontend/src/posts/ai-root-cause-analysis-in-sunbeam.vue vue-frontend/src/data/posts.js`
- `npx prettier -c vue-frontend/src/posts/ai-root-cause-analysis-in-sunbeam.vue vue-frontend/src/data/posts.js`


------
https://chatgpt.com/codex/tasks/task_e_6869f8de89288323a3c663f9c2fcee75