### PR TITLE
Add honeycomb skills component

### DIFF
--- a/vue-frontend/src/components/SkillHoneycomb.vue
+++ b/vue-frontend/src/components/SkillHoneycomb.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="honeycomb">
+    <div
+      v-for="(layer, index) in layers"
+      :key="index"
+      class="hex-row"
+      :class="{ offset: index % 2 === 1 }"
+    >
+      <div v-for="skill in layer" :key="skill.label" class="hex">
+        <div class="hex-inner">
+          <i :class="skill.icon" class="hex-icon"></i>
+          <span class="hex-label">{{ skill.label }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  layers: {
+    type: Array,
+    required: true,
+  },
+});
+</script>
+
+<style scoped>
+.honeycomb {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.hex-row {
+  display: flex;
+}
+.hex-row.offset {
+  margin-left: 55px;
+}
+.hex {
+  width: 110px;
+  height: 63px;
+  margin: 31.5px 5px;
+  position: relative;
+}
+.hex-inner {
+  width: 100%;
+  height: 100%;
+  background-color: var(--v-theme-primary, #2e7d32);
+  clip-path: polygon(50% 0%, 93% 25%, 93% 75%, 50% 100%, 7% 75%, 7% 25%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: white;
+}
+.hex-icon {
+  font-size: 24px;
+  line-height: 1;
+}
+.hex-label {
+  font-size: 0.75rem;
+}
+@media (max-width: 600px) {
+  .hex-row.offset {
+    margin-left: 27px;
+  }
+  .hex {
+    width: 60px;
+    height: 34px;
+    margin: 17px 3px;
+  }
+  .hex-icon {
+    font-size: 16px;
+  }
+  .hex-label {
+    font-size: 0.55rem;
+  }
+}
+</style>

--- a/vue-frontend/src/views/Home.vue
+++ b/vue-frontend/src/views/Home.vue
@@ -1,6 +1,7 @@
 <script setup>
 import Hero from "../components/Hero.vue";
 import Frisbee from "../svgs/Frisbee.vue";
+import SkillHoneycomb from "../components/SkillHoneycomb.vue";
 
 const certs = [
   {
@@ -37,6 +38,32 @@ const certs = [
   },
 ];
 
+const layers = [
+  [
+    { label: "Codex", icon: "fas fa-robot" },
+    { label: "CoPilot", icon: "fas fa-user-astronaut" },
+    { label: "LangChain", icon: "fas fa-link" },
+  ],
+  [
+    { label: "Cloud Practitioner", icon: "fab fa-aws" },
+    { label: "AI Practitioner", icon: "fab fa-aws" },
+    { label: "Developer", icon: "fab fa-aws" },
+    { label: "DevOps Pro", icon: "fab fa-aws" },
+  ],
+  [
+    { label: "Data Engineering", icon: "fas fa-database" },
+    { label: "Bioinformatics", icon: "fas fa-dna" },
+    { label: "Snakemake", icon: "fas fa-network-wired" },
+    { label: "Prefect", icon: "fas fa-check-circle" },
+  ],
+  [
+    { label: "Python", icon: "fab fa-python" },
+    { label: "Terraform", icon: "fas fa-cubes" },
+    { label: "JavaScript", icon: "fab fa-js" },
+    { label: "R", icon: "fab fa-r-project" },
+  ],
+];
+
 const buttons = [
   { to: "/pcmp", label: "Work", icon: "fas fa-briefcase" },
   { to: "/projects", label: "Projects", icon: "fas fa-project-diagram" },
@@ -54,7 +81,7 @@ const buttons = [
     title="Charlie Bushman"
     subtitle="Full-Stack Software Engineer with Cloud, DevOps, and Python expertise. Impactful results pushing projects from ideation, to creation, to production. Always eager to learn new technologies, fields, and fun facts."
   >
-  <v-row justify="center" class="mt-4">
+    <v-row justify="center" class="mt-4">
       <router-link to="/resume">
         <v-btn
           color="green-darken-2"
@@ -80,6 +107,8 @@ const buttons = [
       </v-col>
     </v-row>
   </Hero>
+
+  <SkillHoneycomb :layers="layers" class="my-8" />
 
   <v-container class="text-center">
     <v-row justify="center">


### PR DESCRIPTION
## Summary
- create `SkillHoneycomb` component to display skills in a hexagon grid
- add skill data and component to home page

## Testing
- `npx prettier --check vue-frontend/src/components/SkillHoneycomb.vue vue-frontend/src/views/Home.vue`

------
https://chatgpt.com/codex/tasks/task_e_686de243be94832392cf970ef1f615a6