### PR TITLE
Add PDF links to blog posts

### DIFF
--- a/vue-frontend/src/posts/comps.vue
+++ b/vue-frontend/src/posts/comps.vue
@@ -404,6 +404,15 @@ onMounted(() => {
       >
         <v-icon icon="fas fa-file-alt"></v-icon>
       </v-btn>
+      <v-btn
+        href="/assets/slides/comps_slides.pptx"
+        icon
+        variant="text"
+        target="_blank"
+        class="mx-2"
+      >
+        <v-icon icon="fas fa-file-powerpoint"></v-icon>
+      </v-btn>
     </div>
   </v-container>
 </template>

--- a/vue-frontend/src/posts/comps.vue
+++ b/vue-frontend/src/posts/comps.vue
@@ -395,6 +395,16 @@ onMounted(() => {
       reservoir. Maybe I'll write more about those here in the
       future.</Paragraph
     >
+    <div class="text-center my-4">
+      <v-btn
+        href="/assets/documents/comps_paper.pdf"
+        icon
+        variant="text"
+        target="_blank"
+      >
+        <v-icon icon="fas fa-file-alt"></v-icon>
+      </v-btn>
+    </div>
   </v-container>
 </template>
 

--- a/vue-frontend/src/posts/firewalls-in-china.vue
+++ b/vue-frontend/src/posts/firewalls-in-china.vue
@@ -72,5 +72,25 @@ const info = posts[slug];
       Chinese and most of it no longer comes naturally. Maybe someday I'll have
       reason to revive it.</Paragraph
     >
+    <div class="text-center my-4">
+      <v-btn
+        href="/assets/documents/firewalls_paper.pdf"
+        icon
+        variant="text"
+        target="_blank"
+        class="mx-2"
+      >
+        <v-icon icon="fas fa-file-alt"></v-icon>
+      </v-btn>
+      <v-btn
+        href="/assets/documents/firewalls_mini_papers.pdf"
+        icon
+        variant="text"
+        target="_blank"
+        class="mx-2"
+      >
+        <v-icon icon="fas fa-file-alt"></v-icon>
+      </v-btn>
+    </div>
   </v-container>
 </template>

--- a/vue-frontend/src/posts/qkd.vue
+++ b/vue-frontend/src/posts/qkd.vue
@@ -123,5 +123,15 @@ const info = posts[slug];
       access in ways that make the universe work as we know it. Now you're
       ready, enjoy!</Paragraph
     >
+    <div class="text-center my-4">
+      <v-btn
+        href="/assets/documents/qkd_paper.pdf"
+        icon
+        variant="text"
+        target="_blank"
+      >
+        <v-icon icon="fas fa-file-alt"></v-icon>
+      </v-btn>
+    </div>
   </v-container>
 </template>

--- a/vue-frontend/src/posts/qkd.vue
+++ b/vue-frontend/src/posts/qkd.vue
@@ -129,6 +129,7 @@ const info = posts[slug];
         icon
         variant="text"
         target="_blank"
+        rel="noopener noreferrer"
       >
         <v-icon icon="fas fa-file-alt"></v-icon>
       </v-btn>

--- a/vue-frontend/src/views/PastWork.vue
+++ b/vue-frontend/src/views/PastWork.vue
@@ -6,6 +6,7 @@ const workCards = [
     title: "Lead Developer for Nightly",
     body: "In college a friend pitched a party planning app for a startup competition. I built a prototype with React Native and AWS Amplify and later helped refine the web and mobile apps alongside a small team before joining the PCMP.",
     img: `/assets/images/latenite_logo.png`,
+    link: `/assets/slides/latenite_slides.pptx`,
   },
   {
     title: "HPE Software Internship",


### PR DESCRIPTION
## Summary
- add paper icon for QKD blog post
- add icons for Firewalls in China blog post with two PDFs
- add icon for comps blog post

## Testing
- `npx prettier --config .prettierrc.json --check "vue-frontend/**/*.{js,vue,css,html}" "terraform/**/*.js"`
- `terraform fmt -check -recursive terraform` *(fails: terraform not found)*
- `tidy -qe vue-frontend/index.html` *(fails: tidy not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec703e99083239d4972b196302fb3