### PR TITLE
Fix S3 hash for large files

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -79,7 +79,7 @@ resource "aws_s3_object" "asset" {
     lower(element(reverse(split(".", each.key)), 0)),
     "binary/octet-stream",
   )
-  etag = filemd5("${local.assets_dir}/${each.value}")
+  source_hash = filesha256("${local.assets_dir}/${each.value}")
 }
 
 resource "aws_cloudfront_origin_access_identity" "this" {


### PR DESCRIPTION
## Summary
- improve handling of large assets in Terraform

## Testing
- `npx prettier --config .prettierrc.json -w "vue-frontend/**/*.{js,vue,css,html}" "terraform/**/*.js"`
- `terraform fmt -check -recursive terraform`
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*

------
https://chatgpt.com/codex/tasks/task_e_686ec91ee6f08323b3276699062e8613