### PR TITLE
Fix hero width for certifications

### DIFF
--- a/vue-frontend/src/components/Hero.vue
+++ b/vue-frontend/src/components/Hero.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container class="mt-8 text-center">
     <v-row justify="center">
-      <v-col cols="12" md="6">
+      <v-col cols="12" :md="md">
         <h1 class="text-h4 font-weight-bold mb-2">{{ title }}</h1>
         <p v-html="subtitle" class="text-subtitle-1"></p>
         <slot />
@@ -13,5 +13,9 @@
 defineProps({
   title: String,
   subtitle: String,
+  md: {
+    type: [Number, String],
+    default: 6,
+  },
 });
 </script>

--- a/vue-frontend/src/views/Home.vue
+++ b/vue-frontend/src/views/Home.vue
@@ -53,6 +53,7 @@ const buttons = [
   <Hero
     title="Charlie Bushman"
     subtitle="Full-Stack Software Engineer with Cloud, DevOps, and Python expertise. Impactful results pushing projects from ideation, to creation, to production. Always eager to learn new technologies, fields, and fun facts."
+    md="12"
   >
     <v-row justify="center" class="mt-4">
       <router-link to="/resume">


### PR DESCRIPTION
## Summary
- allow customizing `md` width prop in `Hero` component
- set `Home.vue` hero width to `md=12` so certifications fit on one row

## Testing
- `npx prettier -w vue-frontend/src/components/Hero.vue vue-frontend/src/views/Home.vue`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686edc4cf0cc8323b4c306f9b38273af