### PR TITLE
Add lambda for Spotify data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ dist-ssr
 crash.log
 override.tf
 override.tf.json
+lambda/*.zip
+

--- a/lambda/spotify-playlists/index.js
+++ b/lambda/spotify-playlists/index.js
@@ -1,0 +1,74 @@
+const CLIENT_ID = process.env.SPOTIFY_CLIENT_ID;
+const CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET;
+
+exports.handler = async function () {
+  try {
+    const tokenRes = await fetch("https://accounts.spotify.com/api/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Authorization:
+          "Basic " +
+          Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString("base64"),
+      },
+      body: "grant_type=client_credentials",
+    });
+    const tokenData = await tokenRes.json();
+    const token = tokenData.access_token;
+
+    let url =
+      "https://api.spotify.com/v1/users/charlie_bushman/playlists?limit=50";
+    const playlists = [];
+    while (url) {
+      const res = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      playlists.push(...(data.items || []).filter(Boolean));
+      url = data.next;
+    }
+
+    const regex = /[A-Z][a-z]{2} ['‘]\d{2}/;
+    const months = [
+      "Jan",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun",
+      "Jul",
+      "Aug",
+      "Sep",
+      "Oct",
+      "Nov",
+      "Dec",
+    ];
+    const filtered = playlists
+      .filter((p) => regex.test(p.name))
+      .map((p) => ({ ...p, name: p.name.replace("‘", "'") }));
+
+    filtered.sort((a, b) => {
+      const aYear = parseInt(a.name.slice(-2));
+      const bYear = parseInt(b.name.slice(-2));
+      if (aYear !== bYear) return bYear - aYear;
+      const aMonth = months.indexOf(a.name.slice(0, 3));
+      const bMonth = months.indexOf(b.name.slice(0, 3));
+      return bMonth - aMonth;
+    });
+
+    const result = filtered.map((p) => ({
+      name: p.name,
+      url: p.external_urls?.spotify || "#",
+      image: (p.images && p.images[2] && p.images[2].url) || "#",
+    }));
+
+    return {
+      statusCode: 200,
+      headers: { "Access-Control-Allow-Origin": "*" },
+      body: JSON.stringify(result),
+    };
+  } catch (e) {
+    console.error("Failed to fetch playlists", e);
+    return { statusCode: 500, body: "error" };
+  }
+};

--- a/vue-frontend/src/views/Music.vue
+++ b/vue-frontend/src/views/Music.vue
@@ -2,70 +2,15 @@
 import { ref, onMounted } from "vue";
 import Hero from "../components/Hero.vue";
 
-const CLIENT_ID = "SPOTIFY_CLIENT_ID";
-const CLIENT_SECRET = "SPOTIFY_CLIENT_SECRET";
+const PLAYLISTS_URL = "SPOTIFY_PLAYLISTS_URL";
 
 const monthlies = ref([]);
 
 async function fetchMonthlyPlaylists() {
   try {
-    const tokenRes = await fetch("https://accounts.spotify.com/api/token", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-        Authorization: "Basic " + btoa(`${CLIENT_ID}:${CLIENT_SECRET}`),
-      },
-      body: "grant_type=client_credentials",
-    });
-    const tokenData = await tokenRes.json();
-    const token = tokenData.access_token;
-
-    let url =
-      "https://api.spotify.com/v1/users/charlie_bushman/playlists?limit=50";
-    const playlists = [];
-    while (url) {
-      const res = await fetch(url, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      const data = await res.json();
-      playlists.push(...data.items.filter(Boolean));
-      url = data.next;
-    }
-
-    const regex = /[A-Z][a-z]{2} ['‘]\d{2}/;
-    const months = [
-      "Jan",
-      "Feb",
-      "Mar",
-      "Apr",
-      "May",
-      "Jun",
-      "Jul",
-      "Aug",
-      "Sep",
-      "Oct",
-      "Nov",
-      "Dec",
-    ];
-
-    const filtered = playlists
-      .filter((p) => regex.test(p.name))
-      .map((p) => ({ ...p, name: p.name.replace("‘", "'") }));
-
-    filtered.sort((a, b) => {
-      const aYear = parseInt(a.name.slice(-2));
-      const bYear = parseInt(b.name.slice(-2));
-      if (aYear !== bYear) return bYear - aYear;
-      const aMonth = months.indexOf(a.name.slice(0, 3));
-      const bMonth = months.indexOf(b.name.slice(0, 3));
-      return bMonth - aMonth;
-    });
-
-    monthlies.value = filtered.map((p) => ({
-      name: p.name,
-      url: p.external_urls?.spotify || "#",
-      image: (p.images && p.images[2] && p.images[2].url) || "#",
-    }));
+    const res = await fetch(PLAYLISTS_URL);
+    if (!res.ok) throw new Error("Failed to fetch playlists");
+    monthlies.value = await res.json();
   } catch (e) {
     console.error("Failed to fetch playlists", e);
   }


### PR DESCRIPTION
## Summary
- create new lambda function to fetch Spotify playlists securely
- inject new function URL via Terraform placeholders
- call lambda from music view instead of direct Spotify credentials
- ignore generated lambda zip files

## Testing
- `npx prettier --config .prettierrc.json --check vue-frontend/src/views/Music.vue lambda/spotify-playlists/index.js`
- `npx prettier --config .prettierrc.json --check "vue-frontend/**/*.{js,vue,css,html}" "terraform/**/*.js" "lambda/**/*.js"` *(fails: Code style issues found in vue-frontend/src/data/posts.js)*
- `tidy -qe vue-frontend/index.html`
- `terraform -chdir=terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*
- `terraform -chdir=terraform validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_686ee2fae360832397c8fe1cfddafea3