### PR TITLE
Fix CORS on lambda errors

### DIFF
--- a/lambda/spotify-playlists/index.js
+++ b/lambda/spotify-playlists/index.js
@@ -1,8 +1,23 @@
 const CLIENT_ID = process.env.SPOTIFY_CLIENT_ID;
 const CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET;
 
-exports.handler = async function () {
+exports.handler = async function (event) {
+  const origin = event?.headers?.origin;
+  let corsOrigin = "https://charliebushman.com";
   try {
+    if (origin) {
+      try {
+        const { hostname } = new URL(origin);
+        if (
+          hostname === "charliebushman.com" ||
+          hostname.endsWith(".charliebushman.com")
+        ) {
+          corsOrigin = origin;
+        }
+      } catch (_) {
+        // ignore invalid origin
+      }
+    }
     const tokenRes = await fetch("https://accounts.spotify.com/api/token", {
       method: "POST",
       headers: {
@@ -64,11 +79,15 @@ exports.handler = async function () {
 
     return {
       statusCode: 200,
-      headers: { "Access-Control-Allow-Origin": "*" },
+      headers: { "Access-Control-Allow-Origin": corsOrigin },
       body: JSON.stringify(result),
     };
   } catch (e) {
     console.error("Failed to fetch playlists", e);
-    return { statusCode: 500, body: "error" };
+    return {
+      statusCode: 500,
+      headers: { "Access-Control-Allow-Origin": corsOrigin },
+      body: "error",
+    };
   }
 };

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -84,6 +84,7 @@ resource "aws_lambda_function" "spotify_playlists" {
   runtime          = "nodejs20.x"
   filename         = data.archive_file.spotify_playlists.output_path
   source_code_hash = data.archive_file.spotify_playlists.output_base64sha256
+  timeout          = 15
   environment {
     variables = {
       SPOTIFY_CLIENT_ID     = var.spotify_client_id


### PR DESCRIPTION
## Summary
- return CORS headers even on Lambda errors
- raise Lambda timeout to 15s for long Spotify calls
- set dynamic Access-Control-Allow-Origin header for charliebushman.com

## Testing
- `npx prettier --write lambda/spotify-playlists/index.js`
- `terraform fmt -check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870348ca0bc832381247813e42a519f