### PR TITLE
Add loading spinner when fetching playlists

### DIFF
--- a/vue-frontend/src/views/Music.vue
+++ b/vue-frontend/src/views/Music.vue
@@ -5,14 +5,18 @@ import Hero from "../components/Hero.vue";
 const PLAYLISTS_URL = "SPOTIFY_PLAYLISTS_URL";
 
 const monthlies = ref([]);
+const loading = ref(true);
 
 async function fetchMonthlyPlaylists() {
+  loading.value = true;
   try {
     const res = await fetch(PLAYLISTS_URL);
     if (!res.ok) throw new Error("Failed to fetch playlists");
     monthlies.value = await res.json();
   } catch (e) {
     console.error("Failed to fetch playlists", e);
+  } finally {
+    loading.value = false;
   }
 }
 
@@ -42,7 +46,10 @@ onMounted(fetchMonthlyPlaylists);
         <v-icon icon="fa-solid fa-globe" />
       </v-btn>
     </div>
-    <div class="d-flex flex-wrap justify-center">
+    <v-container class="py-8 d-flex justify-center" v-if="loading">
+      <v-progress-circular indeterminate aria-label="Loading playlists..." />
+    </v-container>
+    <div class="d-flex flex-wrap justify-center" v-else>
       <div v-for="p in monthlies" :key="p.name" class="text-center ma-2">
         <a :href="p.url" target="_blank" class="text-decoration-none">
           <h2 class="text-subtitle-1 font-weight-bold">{{ p.name }}</h2>


### PR DESCRIPTION
## Summary
- add loading state in the music page
- display a Vuetify progress circular while playlists load

## Testing
- `npx prettier --config .prettierrc.json --write vue-frontend/src/views/Music.vue`
- `terraform fmt -recursive` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68708fd681c0832398b1d371626ecb45