### PR TITLE
Add Terraform S3 backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ To deploy the site:
 
 - `git clone git@github.com:Ulthran/ctbus_site.git && cd ctbus_site`
 - `terraform init && terraform apply` to create/update the S3 bucket and
-  CloudFront distribution. The CDN will be
+  CloudFront distribution. Terraform state is stored in an S3 bucket so the
+  configuration can be run locally or in CI/CD. The CDN will be
   reachable at `https://vue.charliebushman.com`.
 
 To run locally, start a simple web server from the `vue-frontend` directory:

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,10 @@
+terraform {
+  backend "s3" {
+    bucket         = "ctbus-site-tfstate"
+    key            = "ctbus_site/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "ctbus-site-tf-locks"
+    encrypt        = true
+  }
+}
+

--- a/vue-frontend/src/data/posts.js
+++ b/vue-frontend/src/data/posts.js
@@ -10,7 +10,12 @@ export default {
     title: "00. AI in Bioinformatics",
     date: "06/05/25",
     mod_date: "06/05/25",
-    tags: ["ai", "bioinformatics", "automation", ":series:ai-in-bioinformatics"],
+    tags: [
+      "ai",
+      "bioinformatics",
+      "automation",
+      ":series:ai-in-bioinformatics",
+    ],
     subtitle:
       "The path towards generating novel research and clinical diagnoses.",
   },

--- a/vue-frontend/src/posts/vibe-coding-in-bioinformatics.vue
+++ b/vue-frontend/src/posts/vibe-coding-in-bioinformatics.vue
@@ -18,6 +18,5 @@ const info = posts[slug];
   />
   <v-container class="py-4 blog-content">
     <SectionTitle>AI as a Developer Tool</SectionTitle>
-    
   </v-container>
 </template>


### PR DESCRIPTION
## Summary
- configure Terraform to use an S3 backend
- document the remote backend in README
- run prettier on frontend files

## Testing
- `npx prettier --config .prettierrc.json --write "vue-frontend/**/*.{js,vue,css,html}" "terraform/**/*.js"`
- `terraform fmt -recursive` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871702d6b088323988ccc347d6f8dd0