### PR TITLE
Fix responsive card layout

### DIFF
--- a/vue-frontend/src/style.css
+++ b/vue-frontend/src/style.css
@@ -132,3 +132,11 @@ button:focus-visible {
 .scrollable-card {
   overflow-x: auto;
 }
+
+.uniform-card {
+  height: 150px;
+}
+
+.uniform-card .v-row {
+  height: 100%;
+}

--- a/vue-frontend/src/views/BlogList.vue
+++ b/vue-frontend/src/views/BlogList.vue
@@ -53,8 +53,12 @@ const filteredPosts = computed(() => {
     </v-row>
     <v-row>
       <v-col v-for="(post, name) in filteredPosts" :key="name" cols="12" md="6">
-        <v-card class="ma-2 scrollable-card" :to="`/blog/${name}`" link>
-          <v-row no-gutters>
+        <v-card
+          class="ma-2 scrollable-card uniform-card"
+          :to="`/blog/${name}`"
+          link
+        >
+          <v-row no-gutters align="center">
             <v-col cols="auto">
               <v-img
                 :src="`/assets/images/blog/${name.replace(/-/g, '_')}.png`"

--- a/vue-frontend/src/views/ProjectsList.vue
+++ b/vue-frontend/src/views/ProjectsList.vue
@@ -7,8 +7,12 @@ const projects = window.projects;
     <h1 class="text-h5 font-weight-bold mb-4">Projects</h1>
     <v-row>
       <v-col v-for="(proj, name) in projects" :key="name" cols="12" md="6">
-        <v-card class="ma-2 scrollable-card" :to="`/projects/${name}`" link>
-          <v-row no-gutters>
+        <v-card
+          class="ma-2 scrollable-card uniform-card"
+          :to="`/projects/${name}`"
+          link
+        >
+          <v-row no-gutters align="center">
             <v-col cols="auto">
               <v-img
                 :src="`/assets/images/${proj.image}`"


### PR DESCRIPTION
## Summary
- adjust blog list and project list to use card grid layout
- make cards horizontally scrollable when they overflow

## Testing
- `npx prettier --config .prettierrc.json --write "vue-frontend/**/*.{js,vue,css,html}" "terraform/**/*.js"`
- `terraform fmt -recursive`


------
https://chatgpt.com/codex/tasks/task_e_6876ad60a0cc8323975ef4417457dc76