### PR TITLE
Fix mobile truncation for lists

### DIFF
--- a/vue-frontend/src/style.css
+++ b/vue-frontend/src/style.css
@@ -128,3 +128,13 @@ button:focus-visible {
 .blog-filter {
   max-width: 220px;
 }
+
+@media (max-width: 600px) {
+  .v-list-item-title,
+  .v-list-item-subtitle,
+  .v-list-item-subtitle.text-caption {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: initial;
+  }
+}


### PR DESCRIPTION
## Summary
- allow list titles and subtitles to wrap on small screens
- expand responsive rule to cover dates

## Testing
- `npx prettier --config .prettierrc.json --write "vue-frontend/**/*.{js,vue,css,html}" "terraform/**/*.js"`
- `terraform fmt -recursive`


------
https://chatgpt.com/codex/tasks/task_e_6876c5f136988323aa6ab71539dc2da7