### PR TITLE
Fix text wrapping for card titles

### DIFF
--- a/vue-frontend/index.html
+++ b/vue-frontend/index.html
@@ -16,7 +16,7 @@
       integrity="sha384-t1nt8BQoYMLFN5p42tRAtuAAFQaCQODekUVeKKZrEnEyp4H2R0RHFz0KWpmj7i8g"
       crossorigin="anonymous"
     />
-    <!--<link rel="stylesheet" href="/src/style.css">-->
+    <link rel="stylesheet" href="/src/style.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"

--- a/vue-frontend/src/style.css
+++ b/vue-frontend/src/style.css
@@ -132,9 +132,11 @@ button:focus-visible {
 @media (max-width: 600px) {
   .v-list-item-title,
   .v-list-item-subtitle,
-  .v-list-item-subtitle.text-caption {
-    white-space: normal;
-    overflow: visible;
-    text-overflow: initial;
+  .v-list-item-subtitle.text-caption,
+  .v-card-title,
+  .v-card-subtitle {
+    white-space: normal !important;
+    overflow: visible !important;
+    text-overflow: unset !important;
   }
 }


### PR DESCRIPTION
## Summary
- load global CSS
- adjust styling for card titles and subtitles on small screens

## Testing
- `npx prettier --config .prettierrc.json --write "vue-frontend/**/*.{js,vue,css,html}" "terraform/**/*.js"`
- `terraform fmt -recursive` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877082533a0832380dee3442838224a