### PR TITLE
Add dev server script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ To deploy the site:
   `terraform apply -var-file terraform/production.tfvars`.
   This deploys both `charliebushman.com` and `www.charliebushman.com`.
   
-To run locally, start a simple web server from the `vue-frontend` directory:
+To run locally, start the included Python development server:
 
-- `cd vue-frontend && python3 -m http.server`
+- `python3 dev_server.py`
 
 Then open the given address in your browser.
 

--- a/dev_server.py
+++ b/dev_server.py
@@ -24,8 +24,7 @@ class SPARequestHandler(http.server.SimpleHTTPRequestHandler):
 
 
 def run(port: int, directory: str) -> None:
-    os.chdir(directory)
-    handler = SPARequestHandler
+    handler = lambda *args, **kwargs: SPARequestHandler(*args, directory=directory, **kwargs)
     with socketserver.TCPServer(("", port), handler) as httpd:
         print(f"Serving {directory} at http://localhost:{port}")
         try:

--- a/dev_server.py
+++ b/dev_server.py
@@ -16,7 +16,9 @@ class SPARequestHandler(http.server.SimpleHTTPRequestHandler):
 
     def send_head(self):
         path = self.translate_path(self.path)
-        if not os.path.exists(path) and "." not in os.path.basename(self.path):
+        known_extensions = {".html", ".css", ".js", ".png", ".jpg", ".jpeg", ".gif", ".ico", ".svg", ".json"}
+        _, ext = os.path.splitext(self.path)
+        if not os.path.exists(path) and ext not in known_extensions:
             self.path = "/index.html"
         return super().send_head()
 

--- a/dev_server.py
+++ b/dev_server.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Development server for ctbus_site.
+
+Serves files from the vue-frontend directory and falls back to index.html for
+routes without a file extension. Useful for local SPA development.
+"""
+
+import argparse
+import http.server
+import os
+import socketserver
+
+
+class SPARequestHandler(http.server.SimpleHTTPRequestHandler):
+    """Serve index.html for any path without a file extension."""
+
+    def send_head(self):
+        path = self.translate_path(self.path)
+        if not os.path.exists(path) and "." not in os.path.basename(self.path):
+            self.path = "/index.html"
+        return super().send_head()
+
+
+def run(port: int, directory: str) -> None:
+    os.chdir(directory)
+    handler = SPARequestHandler
+    with socketserver.TCPServer(("", port), handler) as httpd:
+        print(f"Serving {directory} at http://localhost:{port}")
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print("\nStopping server...")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run local dev server.")
+    parser.add_argument("--port", "-p", type=int, default=8000)
+    parser.add_argument(
+        "--dir",
+        "-d",
+        default="vue-frontend",
+        help="Directory to serve",
+    )
+    args = parser.parse_args()
+    run(args.port, args.dir)


### PR DESCRIPTION
## Summary
- add a lightweight Python server for local development
- document using the server

## Testing
- `npx prettier --config .prettierrc.json --write "vue-frontend/**/*.{js,vue,css,html}" "terraform/**/*.js"`
- `terraform fmt -recursive` *(fails: `terraform` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687e572f5a808323a057deeb65aa4e4d