### PR TITLE
Fix project loading message

### DIFF
--- a/frontend/src/src/views/ProjectDetail.vue
+++ b/frontend/src/src/views/ProjectDetail.vue
@@ -2,19 +2,31 @@
 import { useRoute } from "vue-router";
 import { ref, watch } from "vue";
 
+const loading = ref(true);
+const notFound = ref(false);
+
 const route = useRoute();
 const component = ref(null);
 
 async function loadComponent() {
+  loading.value = true;
+  notFound.value = false;
+  component.value = null;
   const name = route.params.slug;
   try {
     component.value = await window["vue3-sfc-loader"].loadModule(
       `${window.projectsPath}/${name}.vue`,
       window.loaderOptions
     );
+    if (!component.value) {
+      notFound.value = true;
+    }
   } catch (e) {
     console.error("Failed to load component:", e);
     component.value = null;
+    notFound.value = true;
+  } finally {
+    loading.value = false;
   }
 }
 
@@ -28,6 +40,9 @@ watch(
 </script>
 
 <template>
-  <component :is="component" v-if="component" />
-  <v-container v-else>Project not found.</v-container>
+  <v-container class="py-8 d-flex justify-center" v-if="loading">
+    <v-progress-circular indeterminate aria-label="Loading project..." />
+  </v-container>
+  <component :is="component" v-else-if="component" />
+  <v-container v-else-if="notFound">Project not found.</v-container>
 </template>


### PR DESCRIPTION
## Summary
- show a progress spinner while projects load
- mark project as not found on failure

## Testing
- `npx prettier --config .prettierrc.json --write "frontend/**/*.{js,vue,css,html}"`
- `terraform fmt -recursive` *(fails: `terraform` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fe12baa8083238413f78335113cfd