### PR TITLE
Add maintenance Lambda service

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,49 @@
+name: maintenance
+
+on:
+  push:
+    branches: [main, master, dev]
+    paths:
+      - 'maintenance/**'
+      - '.github/workflows/maintenance.yml'
+  pull_request:
+    branches: [main, master, dev]
+    paths:
+      - 'maintenance/**'
+      - '.github/workflows/maintenance.yml'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Install tools
+        run: |
+          sudo apt-get update
+          npm install -g prettier
+
+      - name: Prettier Check
+        run: |
+          prettier --config .prettierrc.json --check "maintenance/**/*.js"
+
+      - name: Terraform Format
+        run: terraform fmt -check -recursive
+        working-directory: maintenance/terraform
+
+      - name: Terraform Init
+        run: terraform init -backend=false
+        working-directory: maintenance/terraform
+
+      - name: Terraform Validate
+        run: terraform validate
+        working-directory: maintenance/terraform

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## About
 
-This is a personal website for Charlie Bushman. It is a serverless, microservice grid comprised of a static assets CDN, the Vue frontend CDN, and an additional API for accessing third party data sources. Each service is managed with Terraform.
+This is a personal website for Charlie Bushman. It is a serverless, microservice grid comprised of a static assets CDN, the Vue frontend CDN, an additional API for accessing third party data sources, and a maintenance Lambda for downtime messaging. Each service is managed with Terraform.
 
 <https://charliebushman.com>
 
@@ -20,7 +20,7 @@ terraform -chdir=frontend/terraform init
 terraform -chdir=frontend/terraform apply -var 'hostname=subdomain.example.com'
 ```
 
-Use similar commands for `assets/terraform` and `spotify/terraform`.
+Use similar commands for `assets/terraform`, `spotify/terraform`, and `maintenance/terraform`.
 
 NOTE: The frontend service requires deployed versions of each other service (pulled from the remote Terraform state files).
   

--- a/maintenance/lambda/index.js
+++ b/maintenance/lambda/index.js
@@ -1,0 +1,8 @@
+exports.handler = async function () {
+  const body = `<!DOCTYPE html><html><head><title>Maintenance</title></head><body><h1>Maintenance in progress</h1></body></html>`;
+  return {
+    statusCode: 200,
+    headers: { "Content-Type": "text/html" },
+    body,
+  };
+};

--- a/maintenance/lambda/index.js
+++ b/maintenance/lambda/index.js
@@ -1,5 +1,15 @@
 exports.handler = async function () {
-  const body = `<!DOCTYPE html><html><head><title>Maintenance</title></head><body><h1>Maintenance in progress</h1></body></html>`;
+  const body = `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Maintenance</title>
+      </head>
+      <body>
+        <h1>Maintenance in progress</h1>
+      </body>
+    </html>
+  `;
   return {
     statusCode: 200,
     headers: { "Content-Type": "text/html" },

--- a/maintenance/terraform/backend.tf
+++ b/maintenance/terraform/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "ctbus-tfstates"
+    key          = "ctbus_site/maintenance.tfstate"
+    region       = "us-east-1"
+    use_lockfile = true
+    encrypt      = true
+  }
+}

--- a/maintenance/terraform/main.tf
+++ b/maintenance/terraform/main.tf
@@ -1,0 +1,53 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "archive_file" "maintenance" {
+  type        = "zip"
+  source_file = "${path.module}/../lambda/index.js"
+  output_path = "${path.module}/../lambda/maintenance.zip"
+}
+
+resource "aws_iam_role" "maintenance_lambda" {
+  name = "maintenance-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "maintenance_lambda_basic" {
+  role       = aws_iam_role.maintenance_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_lambda_function" "maintenance" {
+  function_name    = "maintenance"
+  role             = aws_iam_role.maintenance_lambda.arn
+  handler          = "index.handler"
+  runtime          = "nodejs20.x"
+  filename         = data.archive_file.maintenance.output_path
+  source_code_hash = data.archive_file.maintenance.output_base64sha256
+}
+
+resource "aws_lambda_function_url" "maintenance" {
+  function_name      = aws_lambda_function.maintenance.arn
+  authorization_type = "NONE"
+}
+
+resource "aws_lambda_permission" "maintenance_url" {
+  statement_id           = "AllowPublicAccess"
+  action                 = "lambda:InvokeFunctionUrl"
+  function_name          = aws_lambda_function.maintenance.function_name
+  principal              = "*"
+  function_url_auth_type = aws_lambda_function_url.maintenance.authorization_type
+}
+
+output "maintenance_url" {
+  value = aws_lambda_function_url.maintenance.function_url
+}


### PR DESCRIPTION
## Summary
- introduce maintenance Lambda to display downtime message
- add CI workflow for the new service
- document the service in the README

## Testing
- `npx prettier --config .prettierrc.json --write "frontend/**/*.{js,vue,css,html}" "spotify/lambda/**/*.js" "maintenance/lambda/**/*.js"`
- `terraform fmt -recursive`
- `terraform -chdir=maintenance/terraform init -backend=false` *(fails: could not connect to registry)*

------
https://chatgpt.com/codex/tasks/task_e_6881241077e883238381901a361203b5