### PR TITLE
Use fixed ACM certificate ARN

### DIFF
--- a/assets/terraform/main.tf
+++ b/assets/terraform/main.tf
@@ -6,11 +6,6 @@ data "aws_route53_zone" "selected" {
   name = var.zone_name
 }
 
-data "aws_acm_certificate" "wildcard" {
-  domain      = "*.${var.zone_name}"
-  statuses    = ["ISSUED"]
-  most_recent = true
-}
 
 resource "aws_s3_bucket" "this" {
   bucket = var.bucket_name
@@ -93,7 +88,7 @@ resource "aws_cloudfront_distribution" "this" {
 
   price_class = "PriceClass_100"
   viewer_certificate {
-    acm_certificate_arn      = data.aws_acm_certificate.wildcard.arn
+    acm_certificate_arn      = var.certificate_arn
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1.2_2021"
   }

--- a/assets/terraform/variables.tf
+++ b/assets/terraform/variables.tf
@@ -15,3 +15,9 @@ variable "zone_name" {
   description = "Route53 hosted zone"
   default     = "charliebushman.com"
 }
+
+variable "certificate_arn" {
+  type        = string
+  description = "ACM certificate ARN for CloudFront"
+  default     = "arn:aws:acm:us-east-1:832242454463:certificate/f7e30d65-53f8-4852-834a-32d29ca145eb"
+}

--- a/frontend/terraform/main.tf
+++ b/frontend/terraform/main.tf
@@ -1,5 +1,4 @@
 provider "aws" {
-  alias  = "us_east_1"
   region = "us-east-1"
 }
 
@@ -8,12 +7,6 @@ data "aws_route53_zone" "selected" {
   name = var.zone_name
 }
 
-data "aws_acm_certificate" "wildcard" {
-  provider    = aws.us_east_1
-  domain      = "*.${var.zone_name}"
-  statuses    = ["ISSUED"]
-  most_recent = true
-}
 
 # Remote states for other services
 
@@ -173,7 +166,7 @@ resource "aws_cloudfront_distribution" "this" {
 
   price_class = "PriceClass_100"
   viewer_certificate {
-    acm_certificate_arn      = data.aws_acm_certificate.wildcard.arn
+    acm_certificate_arn      = var.certificate_arn
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1.2_2021"
   }

--- a/frontend/terraform/variables.tf
+++ b/frontend/terraform/variables.tf
@@ -20,3 +20,9 @@ variable "zone_name" {
   description = "Route53 hosted zone"
   default     = "charliebushman.com"
 }
+
+variable "certificate_arn" {
+  type        = string
+  description = "ACM certificate ARN for CloudFront"
+  default     = "arn:aws:acm:us-east-1:832242454463:certificate/f7e30d65-53f8-4852-834a-32d29ca145eb"
+}


### PR DESCRIPTION
## Summary
- don't search for ACM certificate in asset/frontend Terraform
- use a variable with default ARN for CloudFront

## Testing
- `npx prettier --config .prettierrc.json --write "frontend/**/*.{js,vue,css,html}" "spotify/lambda/**/*.js"`
- `terraform fmt -recursive`


------
https://chatgpt.com/codex/tasks/task_e_6881b5140d4883238e6382b7fedfdb17