### PR TITLE
Fix external PCMP links

### DIFF
--- a/frontend/src/src/views/PCMP.vue
+++ b/frontend/src/src/views/PCMP.vue
@@ -246,7 +246,7 @@ const others = [
       <v-card
         class="mx-auto"
         :prepend-avatar="proj.img"
-        :to="proj.link"
+        :href="proj.link"
         :target="proj.link ? '_blank' : null"
         width="85%"
       >


### PR DESCRIPTION
## Summary
- on the PCMP page, use `href` instead of `to` so Vuetify does not prefix links

## Testing
- `npx prettier --config .prettierrc.json --write "frontend/**/*.{js,vue,css,html}" "spotify/lambda/**/*.js"`
- `terraform fmt -recursive`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6883c832e8b08323957433ac6e059fdf