### PR TITLE
Add new blog post skeleton

### DIFF
--- a/frontend/src/src/data/posts.js
+++ b/frontend/src/src/data/posts.js
@@ -1,6 +1,15 @@
 export default {
   // There'll probably be a split between practical examples of AI in bioinformatics and my crazy ideas
   // Maybe alternate in the series?
+  "terraform-monolith-to-microservice": {
+    title: "Migrating Terraform from Monolith to Microservice",
+    date: "08/10/25",
+    mod_date: "08/10/25",
+    tags: ["terraform", "devops", "microservice"],
+    subtitle:
+      "Breaking up a single Terraform deployment into modular services.",
+  },
+
   "ai-root-cause-analysis-in-sunbeam": {
     title: "02. AI Root Cause Analysis",
     date: "07/12/25",

--- a/frontend/src/src/posts/terraform-monolith-to-microservice.vue
+++ b/frontend/src/src/posts/terraform-monolith-to-microservice.vue
@@ -1,0 +1,27 @@
+<script setup>
+import BlogHero from "../components/BlogHero.vue";
+import Paragraph from "../components/Paragraph.vue";
+import SectionTitle from "../components/SectionTitle.vue";
+import CodeBlock from "../components/CodeBlock.vue";
+const posts = window.posts;
+const slug = "terraform-monolith-to-microservice";
+const info = posts[slug];
+</script>
+
+<template>
+  <BlogHero
+    :title="info.title"
+    :subtitle="info.subtitle"
+    :date="info.date"
+    :mod_date="info.mod_date"
+    :tags="info.tags"
+    :img="`ASSETS_BASE_URL/images/blog/${slug.replace(/-/g, '_')}.png`"
+  />
+  <v-container class="py-4 blog-content">
+    <SectionTitle>Intro</SectionTitle>
+    <Paragraph>
+      This post will outline the process of migrating Terraform resources from a
+      single monolithic configuration to a microservice-oriented structure.
+    </Paragraph>
+  </v-container>
+</template>


### PR DESCRIPTION
## Summary
- add metadata for 'Migrating Terraform from Monolith to Microservice'
- create skeleton Vue component for upcoming blog post

## Testing
- `npx prettier --config .prettierrc.json --write frontend/src/src/data/posts.js frontend/src/src/posts/terraform-monolith-to-microservice.vue`
- `terraform fmt -recursive`


------
https://chatgpt.com/codex/tasks/task_e_6888e91fa5d483239e4755127585bc21