### PR TITLE
Add CD terraform apply to workflows and IAM role service

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -33,3 +33,32 @@ jobs:
       - name: Terraform Validate
         run: terraform validate
         working-directory: assets/terraform
+
+  deploy:
+    name: Terraform Apply
+    runs-on: ubuntu-latest
+    needs: lint
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_ASSETS }}
+          aws-region: us-east-1
+
+      - name: Terraform Init
+        run: terraform init
+        working-directory: assets/terraform
+
+      - name: Terraform Apply
+        run: terraform apply -auto-approve
+        working-directory: assets/terraform

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -51,3 +51,32 @@ jobs:
 
       - name: Validate HTML
         run: tidy -qe frontend/src/index.html
+
+  deploy:
+    name: Terraform Apply
+    runs-on: ubuntu-latest
+    needs: lint
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_FRONTEND }}
+          aws-region: us-east-1
+
+      - name: Terraform Init
+        run: terraform init
+        working-directory: frontend/terraform
+
+      - name: Terraform Apply
+        run: terraform apply -auto-approve
+        working-directory: frontend/terraform

--- a/.github/workflows/jupyter.yml
+++ b/.github/workflows/jupyter.yml
@@ -33,3 +33,32 @@ jobs:
       - name: Terraform Validate
         run: terraform validate
         working-directory: jupyter/terraform
+
+  deploy:
+    name: Terraform Apply
+    runs-on: ubuntu-latest
+    needs: lint
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_JUPYTER }}
+          aws-region: us-east-1
+
+      - name: Terraform Init
+        run: terraform init
+        working-directory: jupyter/terraform
+
+      - name: Terraform Apply
+        run: terraform apply -auto-approve
+        working-directory: jupyter/terraform

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -47,3 +47,32 @@ jobs:
       - name: Terraform Validate
         run: terraform validate
         working-directory: maintenance/terraform
+
+  deploy:
+    name: Terraform Apply
+    runs-on: ubuntu-latest
+    needs: lint
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_MAINTENANCE }}
+          aws-region: us-east-1
+
+      - name: Terraform Init
+        run: terraform init
+        working-directory: maintenance/terraform
+
+      - name: Terraform Apply
+        run: terraform apply -auto-approve
+        working-directory: maintenance/terraform

--- a/.github/workflows/spotify.yml
+++ b/.github/workflows/spotify.yml
@@ -47,3 +47,32 @@ jobs:
       - name: Terraform Validate
         run: terraform validate
         working-directory: spotify/terraform
+
+  deploy:
+    name: Terraform Apply
+    runs-on: ubuntu-latest
+    needs: lint
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_SPOTIFY }}
+          aws-region: us-east-1
+
+      - name: Terraform Init
+        run: terraform init
+        working-directory: spotify/terraform
+
+      - name: Terraform Apply
+        run: terraform apply -auto-approve
+        working-directory: spotify/terraform

--- a/deploy-roles/README.md
+++ b/deploy-roles/README.md
@@ -10,6 +10,25 @@ default the roles trust workflows from the `charliebushman/ctbus_site`
 repository that run on the `master` or `main` branches. Update the variables
 in [`variables.tf`](terraform/variables.tf) if you need to change the defaults.
 
+## Role permissions
+
+Each role grants only the AWS permissions required by its corresponding
+Terraform project:
+
+- **assets** – manages the `ctbus-site-assets` S3 bucket and objects, the
+  CloudFront distribution and origin access identity that front the bucket, and
+  the Route 53 records for `charliebushman.com`.
+- **frontend** – manages the `ctbus-site-frontend-*` S3 buckets (one per
+  workspace), the SPA rewrite CloudFront Function, the CloudFront distribution,
+  and the Route 53 aliases that point at the distribution.
+- **jupyter** – manages the `ctbus-site-jupyter` S3 bucket and objects, the
+  CloudFront distribution/origin access identity, and the associated Route 53
+  DNS alias.
+- **maintenance** – creates and updates the `maintenance` Lambda function,
+  public function URL, and the dedicated execution IAM role the function uses.
+- **spotify** – creates and updates the `spotify-playlists` Lambda function,
+  its public function URL, and the execution IAM role the Lambda assumes.
+
 ## Usage
 
 ```sh

--- a/deploy-roles/README.md
+++ b/deploy-roles/README.md
@@ -1,0 +1,20 @@
+# Deployment IAM roles
+
+This Terraform project provisions the IAM roles that our GitHub Actions
+workflows assume to run `terraform apply` for each service. There is no CI/CD
+pipeline for this project; apply changes manually whenever new roles or
+permissions are required.
+
+The configuration creates a GitHub OIDC provider and one role per service. By
+default the roles trust workflows from the `charliebushman/ctbus_site`
+repository that run on the `master` or `main` branches. Update the variables
+in [`variables.tf`](terraform/variables.tf) if you need to change the defaults.
+
+## Usage
+
+```sh
+cd terraform
+terraform init
+terraform plan
+terraform apply
+```

--- a/deploy-roles/terraform/backend.tf
+++ b/deploy-roles/terraform/backend.tf
@@ -1,0 +1,16 @@
+terraform {
+  backend "s3" {
+    bucket       = "ctbus-tfstates"
+    key          = "ctbus_site/deploy-roles.tfstate"
+    region       = "us-east-1"
+    use_lockfile = true
+    encrypt      = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/deploy-roles/terraform/main.tf
+++ b/deploy-roles/terraform/main.tf
@@ -57,11 +57,361 @@ resource "aws_iam_role" "deploy" {
   max_session_duration = 3600
 }
 
-resource "aws_iam_role_policy_attachment" "deploy_admin" {
-  for_each = aws_iam_role.deploy
+data "aws_iam_policy_document" "assets_deploy" {
+  statement {
+    sid = "CreateAssetsBucket"
 
-  role       = each.value.name
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+    actions = [
+      "s3:CreateBucket",
+      "s3:ListAllMyBuckets"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "ManageAssetsBucket"
+
+    actions = [
+      "s3:*"
+    ]
+
+    resources = [
+      "arn:aws:s3:::ctbus-site-assets",
+      "arn:aws:s3:::ctbus-site-assets/*"
+    ]
+  }
+
+  statement {
+    sid = "ManageAssetsCloudFront"
+
+    actions = [
+      "cloudfront:CreateCloudFrontOriginAccessIdentity",
+      "cloudfront:CreateDistribution",
+      "cloudfront:DeleteCloudFrontOriginAccessIdentity",
+      "cloudfront:DeleteDistribution",
+      "cloudfront:GetCloudFrontOriginAccessIdentity",
+      "cloudfront:GetCloudFrontOriginAccessIdentityConfig",
+      "cloudfront:GetDistribution",
+      "cloudfront:GetDistributionConfig",
+      "cloudfront:ListTagsForResource",
+      "cloudfront:TagResource",
+      "cloudfront:UntagResource",
+      "cloudfront:UpdateCloudFrontOriginAccessIdentity",
+      "cloudfront:UpdateDistribution"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "ListAssetsHostedZone"
+
+    actions = [
+      "route53:ListHostedZonesByName"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "ManageAssetsDNS"
+
+    actions = [
+      "route53:ChangeResourceRecordSets",
+      "route53:GetHostedZone",
+      "route53:ListResourceRecordSets"
+    ]
+
+    resources = ["arn:aws:route53:::hostedzone/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "assets_deploy" {
+  name   = "assets-deploy"
+  role   = aws_iam_role.deploy["assets"].id
+  policy = data.aws_iam_policy_document.assets_deploy.json
+}
+
+data "aws_iam_policy_document" "frontend_deploy" {
+  statement {
+    sid = "CreateFrontendBucket"
+
+    actions = [
+      "s3:CreateBucket",
+      "s3:ListAllMyBuckets"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "ManageFrontendBuckets"
+
+    actions = [
+      "s3:*"
+    ]
+
+    resources = [
+      "arn:aws:s3:::ctbus-site-frontend-*",
+      "arn:aws:s3:::ctbus-site-frontend-*/*"
+    ]
+  }
+
+  statement {
+    sid = "ManageFrontendCloudFront"
+
+    actions = [
+      "cloudfront:CreateCloudFrontOriginAccessIdentity",
+      "cloudfront:CreateDistribution",
+      "cloudfront:CreateFunction",
+      "cloudfront:DeleteCloudFrontOriginAccessIdentity",
+      "cloudfront:DeleteDistribution",
+      "cloudfront:DeleteFunction",
+      "cloudfront:DescribeFunction",
+      "cloudfront:GetCloudFrontOriginAccessIdentity",
+      "cloudfront:GetCloudFrontOriginAccessIdentityConfig",
+      "cloudfront:GetDistribution",
+      "cloudfront:GetDistributionConfig",
+      "cloudfront:GetFunction",
+      "cloudfront:GetFunctionConfig",
+      "cloudfront:ListTagsForResource",
+      "cloudfront:PublishFunction",
+      "cloudfront:TagResource",
+      "cloudfront:UntagResource",
+      "cloudfront:UpdateCloudFrontOriginAccessIdentity",
+      "cloudfront:UpdateDistribution",
+      "cloudfront:UpdateFunction"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "ListFrontendHostedZone"
+
+    actions = [
+      "route53:ListHostedZonesByName"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "ManageFrontendDNS"
+
+    actions = [
+      "route53:ChangeResourceRecordSets",
+      "route53:GetHostedZone",
+      "route53:ListResourceRecordSets"
+    ]
+
+    resources = ["arn:aws:route53:::hostedzone/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "frontend_deploy" {
+  name   = "frontend-deploy"
+  role   = aws_iam_role.deploy["frontend"].id
+  policy = data.aws_iam_policy_document.frontend_deploy.json
+}
+
+data "aws_iam_policy_document" "jupyter_deploy" {
+  statement {
+    sid = "CreateJupyterBucket"
+
+    actions = [
+      "s3:CreateBucket",
+      "s3:ListAllMyBuckets"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "ManageJupyterBucket"
+
+    actions = [
+      "s3:*"
+    ]
+
+    resources = [
+      "arn:aws:s3:::ctbus-site-jupyter",
+      "arn:aws:s3:::ctbus-site-jupyter/*"
+    ]
+  }
+
+  statement {
+    sid = "ManageJupyterCloudFront"
+
+    actions = [
+      "cloudfront:CreateCloudFrontOriginAccessIdentity",
+      "cloudfront:CreateDistribution",
+      "cloudfront:DeleteCloudFrontOriginAccessIdentity",
+      "cloudfront:DeleteDistribution",
+      "cloudfront:GetCloudFrontOriginAccessIdentity",
+      "cloudfront:GetCloudFrontOriginAccessIdentityConfig",
+      "cloudfront:GetDistribution",
+      "cloudfront:GetDistributionConfig",
+      "cloudfront:ListTagsForResource",
+      "cloudfront:TagResource",
+      "cloudfront:UntagResource",
+      "cloudfront:UpdateCloudFrontOriginAccessIdentity",
+      "cloudfront:UpdateDistribution"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "ListJupyterHostedZone"
+
+    actions = [
+      "route53:ListHostedZonesByName"
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "ManageJupyterDNS"
+
+    actions = [
+      "route53:ChangeResourceRecordSets",
+      "route53:GetHostedZone",
+      "route53:ListResourceRecordSets"
+    ]
+
+    resources = ["arn:aws:route53:::hostedzone/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "jupyter_deploy" {
+  name   = "jupyter-deploy"
+  role   = aws_iam_role.deploy["jupyter"].id
+  policy = data.aws_iam_policy_document.jupyter_deploy.json
+}
+
+data "aws_iam_policy_document" "maintenance_deploy" {
+  statement {
+    sid = "ManageMaintenanceLambda"
+
+    actions = [
+      "lambda:AddPermission",
+      "lambda:CreateFunction",
+      "lambda:CreateFunctionUrlConfig",
+      "lambda:DeleteFunction",
+      "lambda:DeleteFunctionUrlConfig",
+      "lambda:GetFunction",
+      "lambda:GetFunctionConfiguration",
+      "lambda:GetFunctionUrlConfig",
+      "lambda:GetPolicy",
+      "lambda:ListTags",
+      "lambda:TagResource",
+      "lambda:UntagResource",
+      "lambda:UpdateFunctionCode",
+      "lambda:UpdateFunctionConfiguration",
+      "lambda:UpdateFunctionUrlConfig",
+      "lambda:RemovePermission"
+    ]
+
+    resources = ["arn:aws:lambda:${var.region}:*:function:maintenance"]
+  }
+
+  statement {
+    sid = "PassMaintenanceRole"
+
+    actions = [
+      "iam:PassRole"
+    ]
+
+    resources = ["arn:aws:iam::*:role/maintenance-role"]
+  }
+
+  statement {
+    sid = "ManageMaintenanceRole"
+
+    actions = [
+      "iam:AttachRolePolicy",
+      "iam:CreateRole",
+      "iam:DeleteRole",
+      "iam:DetachRolePolicy",
+      "iam:GetRole",
+      "iam:ListAttachedRolePolicies",
+      "iam:TagRole",
+      "iam:UntagRole",
+      "iam:UpdateAssumeRolePolicy"
+    ]
+
+    resources = ["arn:aws:iam::*:role/maintenance-role"]
+  }
+}
+
+resource "aws_iam_role_policy" "maintenance_deploy" {
+  name   = "maintenance-deploy"
+  role   = aws_iam_role.deploy["maintenance"].id
+  policy = data.aws_iam_policy_document.maintenance_deploy.json
+}
+
+data "aws_iam_policy_document" "spotify_deploy" {
+  statement {
+    sid = "ManageSpotifyLambda"
+
+    actions = [
+      "lambda:AddPermission",
+      "lambda:CreateFunction",
+      "lambda:CreateFunctionUrlConfig",
+      "lambda:DeleteFunction",
+      "lambda:DeleteFunctionUrlConfig",
+      "lambda:GetFunction",
+      "lambda:GetFunctionConfiguration",
+      "lambda:GetFunctionUrlConfig",
+      "lambda:GetPolicy",
+      "lambda:ListTags",
+      "lambda:TagResource",
+      "lambda:UntagResource",
+      "lambda:UpdateFunctionCode",
+      "lambda:UpdateFunctionConfiguration",
+      "lambda:UpdateFunctionUrlConfig",
+      "lambda:RemovePermission"
+    ]
+
+    resources = ["arn:aws:lambda:${var.region}:*:function:spotify-playlists"]
+  }
+
+  statement {
+    sid = "PassSpotifyRole"
+
+    actions = [
+      "iam:PassRole"
+    ]
+
+    resources = ["arn:aws:iam::*:role/spotify-playlists-role"]
+  }
+
+  statement {
+    sid = "ManageSpotifyRole"
+
+    actions = [
+      "iam:AttachRolePolicy",
+      "iam:CreateRole",
+      "iam:DeleteRole",
+      "iam:DetachRolePolicy",
+      "iam:GetRole",
+      "iam:ListAttachedRolePolicies",
+      "iam:TagRole",
+      "iam:UntagRole",
+      "iam:UpdateAssumeRolePolicy"
+    ]
+
+    resources = ["arn:aws:iam::*:role/spotify-playlists-role"]
+  }
+}
+
+resource "aws_iam_role_policy" "spotify_deploy" {
+  name   = "spotify-deploy"
+  role   = aws_iam_role.deploy["spotify"].id
+  policy = data.aws_iam_policy_document.spotify_deploy.json
 }
 
 output "role_arns" {

--- a/deploy-roles/terraform/main.tf
+++ b/deploy-roles/terraform/main.tf
@@ -1,0 +1,70 @@
+provider "aws" {
+  region = var.region
+}
+
+locals {
+  services = {
+    assets      = "Assets terraform apply role"
+    frontend    = "Frontend terraform apply role"
+    jupyter     = "Jupyter terraform apply role"
+    maintenance = "Maintenance terraform apply role"
+    spotify     = "Spotify terraform apply role"
+  }
+
+  environment_refs = ["refs/heads/master", "refs/heads/main"]
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  for_each = local.services
+
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values = [
+        for ref in local.environment_refs : "repo:${var.github_owner}/${var.repository}:ref:${ref}"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "deploy" {
+  for_each = local.services
+
+  name                 = "${var.role_name_prefix}-${each.key}-deploy"
+  description          = each.value
+  assume_role_policy   = data.aws_iam_policy_document.assume_role[each.key].json
+  max_session_duration = 3600
+}
+
+resource "aws_iam_role_policy_attachment" "deploy_admin" {
+  for_each = aws_iam_role.deploy
+
+  role       = each.value.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+output "role_arns" {
+  description = "Map of service identifiers to IAM role ARNs"
+  value       = { for key, role in aws_iam_role.deploy : key => role.arn }
+}

--- a/deploy-roles/terraform/variables.tf
+++ b/deploy-roles/terraform/variables.tf
@@ -1,0 +1,23 @@
+variable "region" {
+  type        = string
+  description = "AWS region where IAM roles will be created"
+  default     = "us-east-1"
+}
+
+variable "github_owner" {
+  type        = string
+  description = "GitHub organization or user that owns the repository"
+  default     = "charliebushman"
+}
+
+variable "repository" {
+  type        = string
+  description = "Repository name for which to trust GitHub Actions"
+  default     = "ctbus_site"
+}
+
+variable "role_name_prefix" {
+  type        = string
+  description = "Prefix for IAM role names"
+  default     = "ctbus"
+}


### PR DESCRIPTION
## Summary
- add terraform apply deployment jobs to the assets, frontend, and jupyter workflows so infrastructure changes apply automatically after merges to master
- update the maintenance and spotify workflows to assume service-specific deployment roles
- add a manual deploy-roles Terraform project that provisions the GitHub OIDC provider and IAM roles used by the workflows

## Testing
- prettier --config .prettierrc.json --write "frontend/**/*.{js,vue,css,html}" "spotify/lambda/**/*.js"
- terraform fmt -recursive

------
https://chatgpt.com/codex/tasks/task_e_68eda8de585c83239f759c038f04e9a8