### PR TITLE
Add README for games service deployments

### DIFF
--- a/games/README.md
+++ b/games/README.md
@@ -1,0 +1,28 @@
+# Games Service
+
+Static site for the games experience, deployed to S3/CloudFront via Terraform.
+
+## Deploy (production)
+
+From `games/`:
+
+```sh
+terraform init
+terraform apply
+```
+
+## Run locally
+
+From `games/`:
+
+```sh
+node dev-server.js
+```
+
+Then visit `http://localhost:4173`.
+
+Optional environment overrides:
+
+```sh
+ASSETS_BASE_URL=http://localhost:4173/assets ENV_NAME=local node dev-server.js
+```


### PR DESCRIPTION
### Motivation
- Document the purpose of the games static site and how it is deployed to S3/CloudFront via Terraform.
- Provide simple, discoverable instructions for deploying the production site and running a local test server.

### Description
- Add `games/README.md` containing a brief service description and production deploy steps using `terraform init` and `terraform apply`.
- Include local development instructions to run the dev server with `node dev-server.js` and optional environment overrides `ASSETS_BASE_URL` and `ENV_NAME`.

### Testing
- Ran `prettier --config .prettierrc.json --write "frontend/**/*.{js,vue,css,html}" "spotify/lambda/**/*.js"`, which completed successfully.
- Ran `terraform fmt -recursive`, which failed because `terraform` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f07e2f4108323b4d4f5e535b505b8)