### PR TITLE
Add WHOOP HAX team role and move PCMP to past work

### DIFF
--- a/.claude/skills/watch-ci/SKILL.md
+++ b/.claude/skills/watch-ci/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: watch-ci
+description: Check and wait for GitHub Actions CI results on the current branch or a specific run
+argument-hint: "[run-id]"
+allowed-tools: Bash(gh *)
+---
+
+# Watch CI
+
+Check the status of GitHub Actions workflows for this repo.
+
+## Steps
+
+1. If `$ARGUMENTS` is provided, treat it as a run ID and jump to step 3.
+
+2. Otherwise, list recent runs for the current branch:
+   ```
+   gh run list --branch $(git branch --show-current) --limit 5
+   ```
+   Pick the most recent run (top of the list).
+
+3. Watch the run until it completes (this streams live output and blocks until done):
+   ```
+   gh run watch <run-id>
+   ```
+
+4. Once complete, show the final status:
+   ```
+   gh run view <run-id>
+   ```
+
+5. If any jobs failed, show their logs:
+   ```
+   gh run view <run-id> --log-failed
+   ```
+
+6. Report a plain-language summary: which jobs passed, which failed, and — if there were failures — the most likely cause based on the log output (e.g. Prettier formatting, Terraform validation).

--- a/.claude/skills/watch-ci/SKILL.md
+++ b/.claude/skills/watch-ci/SKILL.md
@@ -13,11 +13,17 @@ Check the status of GitHub Actions workflows for this repo.
 
 1. If `$ARGUMENTS` is provided, treat it as a run ID and jump to step 3.
 
-2. Otherwise, list recent runs for the current branch:
+2. Otherwise, find the most recent run for the current branch. Note: `gh run list`
+   does NOT support `--branch`. Filter using `--json` instead:
    ```
-   gh run list --branch $(git branch --show-current) --limit 5
+   gh run list --limit 20 --json databaseId,status,conclusion,name,headBranch,createdAt
    ```
-   Pick the most recent run (top of the list).
+   Filter the output where `headBranch` matches `$(git branch --show-current)`,
+   then pick the entry with the most recent `createdAt`.
+
+   Valid `--json` fields are: `conclusion`, `createdAt`, `databaseId`, `event`,
+   `headBranch`, `headSha`, `name`, `status`, `updatedAt`, `url`, `workflowDatabaseId`.
+   (`workflowName` is NOT valid — use `name`.)
 
 3. Watch the run until it completes (this streams live output and blocks until done):
    ```
@@ -34,4 +40,7 @@ Check the status of GitHub Actions workflows for this repo.
    gh run view <run-id> --log-failed
    ```
 
-6. Report a plain-language summary: which jobs passed, which failed, and — if there were failures — the most likely cause based on the log output (e.g. Prettier formatting, Terraform validation).
+6. Report a plain-language summary: which jobs passed, which failed, and — if there
+   were failures — the most likely cause based on the log output (e.g. Prettier
+   formatting, Terraform validation). If Prettier is the cause, fix the files and
+   commit before reporting back.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — ctbus_site
 
-Personal portfolio site for Charlie Bushman (charliebushman.com).
+Personal portfolio site for Charlie Bushman (charliebushman.com). Monorepo of microservices deployed via AWS.
 
 ## Repo Structure
 
@@ -21,7 +21,9 @@ ctbus_site/
 └── .github/workflows/  # CI per service area (frontend, assets, spotify, etc.)
 ```
 
-## Key Pages (frontend/src/src/views/)
+## Frontend
+
+### Key Pages (frontend/src/src/views/)
 
 | File | Route | Purpose |
 |------|-------|---------|
@@ -47,6 +49,7 @@ git checkout -b <descriptive-branch-name>
 ### 2. Lint (before committing)
 ```bash
 npx prettier --config .prettierrc.json --write "frontend/**/*.{js,vue,css,html}" "spotify/lambda/**/*.js"
+python -m black example.py another_example.py
 terraform fmt -recursive
 ```
 
@@ -77,5 +80,3 @@ Workflows run per service area on push/PR to `master`/`dev`:
 | `spotify.yml` | `spotify/` | Prettier, Terraform fmt/validate |
 | `jupyter.yml` | `jupyter/` | Terraform fmt/validate |
 | `health-checks.yml` | Scheduled weekly | Broken links, critical docs |
-
-CI failures are almost always Prettier formatting — run the lint command above before committing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,81 @@
+# CLAUDE.md — ctbus_site
+
+Personal portfolio site for Charlie Bushman (charliebushman.com).
+
+## Repo Structure
+
+```
+ctbus_site/
+├── frontend/           # Main Vue.js SPA (served via S3/CloudFront)
+│   ├── src/src/
+│   │   ├── main.js         # Router definitions (add new routes here)
+│   │   ├── App.vue          # Top-level layout, nav links, social icons
+│   │   ├── views/           # One file per page/route
+│   │   └── components/      # Shared components (Hero, Timeline, etc.)
+│   └── terraform/           # AWS infra for frontend
+├── games/              # Separate React games SPA (S3/CloudFront)
+├── assets/             # Static files (images, PDFs, certs) with own terraform
+├── spotify/            # Spotify Lambda integration
+├── jupyter/            # Jupyter notebooks
+├── maintenance/        # Maintenance scripts
+└── .github/workflows/  # CI per service area (frontend, assets, spotify, etc.)
+```
+
+## Key Pages (frontend/src/src/views/)
+
+| File | Route | Purpose |
+|------|-------|---------|
+| `Home.vue` | `/` | Landing page — nav buttons, certs, contact |
+| `About.vue` | `/about` | Career timeline |
+| `WHOOP.vue` | `/whoop` | Current job (Software Engineer, HAX Team) |
+| `PCMP.vue` | `/pcmp` | Previous job (Penn-CHOP Microbiome Program) |
+| `PastWork.vue` | `/past-work` | Internships and older roles |
+| `Resume.vue` | `/resume` | Resume viewer/download |
+| `ProjectsList.vue` | `/projects` | Personal projects list |
+| `Certifications.vue` | `/certifications` | AWS and other certs |
+| `Education.vue` | `/education` | Carleton College, Marblehead HS |
+
+**Adding a new page:** create the `.vue` file in `views/`, add a route object in `main.js`, and add a nav button in `Home.vue` if appropriate.
+
+## Development Workflow
+
+### 1. Branch
+```bash
+git checkout -b <descriptive-branch-name>
+```
+
+### 2. Lint (before committing)
+```bash
+npx prettier --config .prettierrc.json --write "frontend/**/*.{js,vue,css,html}" "spotify/lambda/**/*.js"
+terraform fmt -recursive
+```
+
+### 3. Commit
+Keep messages short and descriptive (one line is fine for small changes):
+```bash
+git add <specific files>
+git commit -m "Short description of what changed"
+```
+
+### 4. Push & PR
+```bash
+git push -u origin <branch-name>
+gh pr create --title "..." --body "..."
+```
+
+Use `/watch-ci` after pushing to monitor GitHub Actions results.
+
+## CI / GitHub Actions
+
+Workflows run per service area on push/PR to `master`/`dev`:
+
+| Workflow | Triggers on changes to | Checks |
+|----------|------------------------|--------|
+| `frontend.yml` | `frontend/` | Prettier, Terraform fmt/validate, HTML tidy |
+| `assets.yml` | `assets/` | Terraform fmt/validate |
+| `maintenance.yml` | `maintenance/` | Prettier, Terraform fmt/validate |
+| `spotify.yml` | `spotify/` | Prettier, Terraform fmt/validate |
+| `jupyter.yml` | `jupyter/` | Terraform fmt/validate |
+| `health-checks.yml` | Scheduled weekly | Broken links, critical docs |
+
+CI failures are almost always Prettier formatting — run the lint command above before committing.

--- a/frontend/src/src/data/projects.js
+++ b/frontend/src/src/data/projects.js
@@ -6,7 +6,7 @@ export default {
     tags: ["aws", "js", "serverless", "terraform"],
     image: "Bvnrihioon.png",
   },
-  "xylblox": {
+  xylblox: {
     title: "Xylblox",
     subtitle:
       "WIP. A Minecraft server hosting SaaS I'm building with AWS, Terraform, and Vue.",
@@ -22,12 +22,11 @@ export default {
   },
   "ctbus-games": {
     title: "CTBus Games",
-    subtitle:
-      "A collection of game development experiments.",
+    subtitle: "A collection of game development experiments.",
     tags: ["react", "javascript", "aws"],
     image: "Bvnrihioon.png",
   },
-  "chaos": {
+  chaos: {
     title: "Fun with Chaos",
     subtitle:
       "A serverless implementation of Jupyter notebooks with a JavaScript kernel for exploring chaotic systems.",
@@ -48,7 +47,7 @@ export default {
     tags: ["aws", "data engineering", "serverless"],
     image: "Bvnrihioon.png",
   },
-  "disctracker": {
+  disctracker: {
     title: "Ultimate DiscTracker",
     subtitle:
       "WIP. The beginnings of an environment for Ultimate Frisbee stat tracking, analytics, real-time AI coaching, and more.",

--- a/frontend/src/src/main.js
+++ b/frontend/src/src/main.js
@@ -133,6 +133,15 @@ window.dataPath = `${basePath}/data`;
             `${window.viewsPath}/PCMP.vue`,
             options
           ),
+        meta: { title: "PCMP - Charlie Bushman" },
+      },
+      {
+        path: "/whoop",
+        component: () =>
+          window["vue3-sfc-loader"].loadModule(
+            `${window.viewsPath}/WHOOP.vue`,
+            options
+          ),
         meta: { title: "Work - Charlie Bushman" },
       },
       {

--- a/frontend/src/src/views/About.vue
+++ b/frontend/src/src/views/About.vue
@@ -4,10 +4,17 @@ import Timeline from "../components/Timeline.vue";
 
 const timelineEvents = [
   {
-    time: "Jan 2022",
-    title: "Developer in Statistical Metagenomics",
+    time: "Mar 2026",
+    title: "Software Engineer, HAX Team at WHOOP",
     content:
-      "My position with the Penn-CHOP Microbiome Program has honed my <b>software development skills</b> and expanded my knowledge about <b>bioinformatics and statistics</b>. It has also shown me how to have an outsized impact on research and development on the basis of my unique skillset, namely driving software standards, encouraging well structured data/metadata, and building the infrastructure to support it.",
+      "I joined WHOOP&#39;s Hardware Accelerate (HAX) team as a Software Engineer, working at the intersection of software and hardware to build reliable systems for WHOOP&#39;s wearable devices.",
+    link: "/whoop",
+  },
+  {
+    time: "Jan 2022",
+    title: "Developer in Statistical Metagenomics at PCMP",
+    content:
+      "My four years with the Penn-CHOP Microbiome Program honed my <b>software development skills</b> and expanded my knowledge about <b>bioinformatics and statistics</b>. It also showed me how to have an outsized impact on research and development on the basis of my unique skillset, namely driving software standards, encouraging well structured data/metadata, and building the infrastructure to support it.",
     link: "/pcmp",
   },
   {
@@ -56,7 +63,7 @@ const timelineEvents = [
 <template>
   <Hero
     title="About Me"
-    subtitle="Building the infrastructure behind <b>reliable</b>, <b>reproducible</b>, and <b>high performance</b> research and development."
+    subtitle="Building <b>reliable</b>, <b>high performance</b> software for impactful products."
   />
   <v-container class="pt-0 pb-10">
     <Timeline :events="timelineEvents" />

--- a/frontend/src/src/views/Home.vue
+++ b/frontend/src/src/views/Home.vue
@@ -37,7 +37,7 @@ const certs = [
 ];
 
 const buttons = [
-  { to: "/pcmp", label: "Work", icon: "fas fa-briefcase" },
+  { to: "/whoop", label: "Work", icon: "fas fa-briefcase" },
   { to: "/projects", label: "Projects", icon: "fas fa-project-diagram" },
   { to: "/blog", label: "Blog", icon: "fas fa-code" },
   { to: "/certifications", label: "Certs", icon: "fas fa-certificate" },

--- a/frontend/src/src/views/PastWork.vue
+++ b/frontend/src/src/views/PastWork.vue
@@ -3,6 +3,12 @@ import Hero from "../components/Hero.vue";
 
 const workCards = [
   {
+    title: "Developer in Statistical Metagenomics at PCMP",
+    body: "For four years I served as the software engineer for the Penn-CHOP Microbiome Program, a joint effort between the Perelman School of Medicine at UPenn and Children's Hospital of Philadelphia. I established development standards, led open source projects, and built internal services ranging from preprocessing automation to AI-enabled web apps.",
+    img: `ASSETS_BASE_URL/images/chop_logo.png`,
+    link: "/pcmp",
+  },
+  {
     title: "Lead Developer for Nightly",
     body: "In college a friend pitched a party planning app for a startup competition. I built a prototype with React Native and AWS Amplify and later helped refine the web and mobile apps alongside a small team before joining the PCMP.",
     img: `ASSETS_BASE_URL/images/latenite_logo.png`,

--- a/frontend/src/src/views/PastWork.vue
+++ b/frontend/src/src/views/PastWork.vue
@@ -40,7 +40,12 @@ const workCards = [
   <v-container>
     <v-row justify="center">
       <v-col cols="12" md="8" v-for="(card, i) in workCards" :key="card.title">
-        <v-card class="ma-4" :href="card.link" target="_blank">
+        <v-card
+          class="ma-4"
+          :href="card.link.startsWith('/') ? undefined : card.link"
+          :to="card.link.startsWith('/') ? card.link : undefined"
+          :target="card.link.startsWith('/') ? undefined : '_blank'"
+        >
           <v-row no-gutters>
             <v-col cols="12" md="4">
               <v-img

--- a/frontend/src/src/views/Sports.vue
+++ b/frontend/src/src/views/Sports.vue
@@ -17,7 +17,8 @@ import SquashIcon from "../svgs/Squash.vue";
       <p class="text-body-1">
         I grew up on the sidelines of my parents' summer league games. Now I
         play for a club team that is nationally competitive (top 20 last year).
-         I also play for the same summer league team my parents did (it's 40 years old!).
+        I also play for the same summer league team my parents did (it's 40
+        years old!).
       </p>
       <v-row class="py-4" align="center" justify="space-around">
         <v-col cols="auto">

--- a/frontend/src/src/views/WHOOP.vue
+++ b/frontend/src/src/views/WHOOP.vue
@@ -10,10 +10,10 @@ import Hero from "../components/Hero.vue";
       <v-col cols="12" md="6" class="text-center">
         <h2 class="text-h6 font-weight-bold mb-2">About WHOOP</h2>
         <p>
-          WHOOP is a performance optimization company that makes wearable
-          fitness trackers focused on recovery, strain, and sleep. The platform
-          helps athletes and everyday users understand their bodies and optimize
-          performance through continuous biometric monitoring.
+          WHOOP makes a leading wearable fitness & health tracker focused on
+          recovery, strain, and sleep. The platform helps athletes and everyday
+          users understand their bodies and optimize performance and health
+          through continuous biometric monitoring.
         </p>
       </v-col>
 
@@ -21,20 +21,9 @@ import Hero from "../components/Hero.vue";
         <h2 class="text-h6 font-weight-bold mb-2">About the HAX Team</h2>
         <p>
           The Hardware Accelerate (HAX) team works at the intersection of
-          software and hardware, building the systems and tooling that power
-          WHOOP&#39;s devices. The team focuses on accelerating hardware
-          development and ensuring the software stack performs reliably on
-          embedded platforms.
-        </p>
-      </v-col>
-
-      <v-col cols="12" md="6" class="text-center">
-        <h2 class="text-h6 font-weight-bold mb-2">My Role</h2>
-        <p>
-          As a Software Engineer on the HAX team, I work on the software systems
-          that support WHOOP&#39;s hardware products. This role builds on my
-          background in building reliable, production-grade software while
-          expanding into the embedded and hardware domains.
+          software, hardware, and signal processing. We build the systems and
+          tooling that power WHOOP&#39;s devices. The team focuses on
+          accelerating the flow of data from studies to development work.
         </p>
       </v-col>
     </v-row>

--- a/frontend/src/src/views/WHOOP.vue
+++ b/frontend/src/src/views/WHOOP.vue
@@ -3,10 +3,7 @@ import Hero from "../components/Hero.vue";
 </script>
 
 <template>
-  <Hero
-    title="Software Engineer, HAX Team"
-    subtitle="WHOOP"
-  />
+  <Hero title="Software Engineer, HAX Team" subtitle="WHOOP" />
 
   <v-container class="text-center">
     <v-row>

--- a/frontend/src/src/views/WHOOP.vue
+++ b/frontend/src/src/views/WHOOP.vue
@@ -1,0 +1,45 @@
+<script setup>
+import Hero from "../components/Hero.vue";
+</script>
+
+<template>
+  <Hero
+    title="Software Engineer, HAX Team"
+    subtitle="WHOOP"
+  />
+
+  <v-container class="text-center">
+    <v-row>
+      <v-col cols="12" md="6" class="text-center">
+        <h2 class="text-h6 font-weight-bold mb-2">About WHOOP</h2>
+        <p>
+          WHOOP is a performance optimization company that makes wearable
+          fitness trackers focused on recovery, strain, and sleep. The platform
+          helps athletes and everyday users understand their bodies and optimize
+          performance through continuous biometric monitoring.
+        </p>
+      </v-col>
+
+      <v-col cols="12" md="6" class="text-center">
+        <h2 class="text-h6 font-weight-bold mb-2">About the HAX Team</h2>
+        <p>
+          The Hardware Accelerate (HAX) team works at the intersection of
+          software and hardware, building the systems and tooling that power
+          WHOOP&#39;s devices. The team focuses on accelerating hardware
+          development and ensuring the software stack performs reliably on
+          embedded platforms.
+        </p>
+      </v-col>
+
+      <v-col cols="12" md="6" class="text-center">
+        <h2 class="text-h6 font-weight-bold mb-2">My Role</h2>
+        <p>
+          As a Software Engineer on the HAX team, I work on the software systems
+          that support WHOOP&#39;s hardware products. This role builds on my
+          background in building reliable, production-grade software while
+          expanding into the embedded and hardware domains.
+        </p>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>


### PR DESCRIPTION
## Summary
- Creates a new `WHOOP.vue` page for the current Software Engineer role on the Hardware Accelerate (HAX) team
- Adds `/whoop` route and updates the Work nav button to point to it
- Adds WHOOP as the newest timeline entry in About (Mar 2026) and updates PCMP entry to past tense
- Adds PCMP as the first card in Past Work with a link to the detail page
- Updates About page subtitle to be role-agnostic

## Test plan
- [x] Visit `/whoop` — new page renders with WHOOP/HAX team content
- [x] Visit `/` — Work button navigates to `/whoop`
- [x] Visit `/about` — WHOOP appears at top of timeline, PCMP below it in past tense
- [x] Visit `/past-work` — PCMP card appears as first entry
- [x] Visit `/pcmp` — existing page still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)