### PR TITLE
Add Notion automations Lambda service

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -19,10 +19,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
 
       - name: Terraform Format
         run: terraform fmt -check -recursive
@@ -45,16 +45,16 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: arn:aws:iam::832242454463:role/github-actions-deploy
           aws-region: us-east-1
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
 
       - name: Terraform Init
         run: terraform init -input=false -no-color

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -19,15 +19,15 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: '20'
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
 
       - name: Install tools
         run: |
@@ -68,16 +68,16 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: arn:aws:iam::832242454463:role/github-actions-deploy
           aws-region: us-east-1
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
 
       - name: Determine workspace
         id: workspace

--- a/.github/workflows/games.yml
+++ b/.github/workflows/games.yml
@@ -19,15 +19,15 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: '20'
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
 
       - name: Install tools
         run: |
@@ -65,16 +65,16 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: arn:aws:iam::832242454463:role/github-actions-deploy
           aws-region: us-east-1
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
 
       - name: Terraform Init
         run: terraform init -input=false -no-color

--- a/.github/workflows/jupyter.yml
+++ b/.github/workflows/jupyter.yml
@@ -19,10 +19,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
 
       - name: Terraform Format
         run: terraform fmt -check -recursive
@@ -45,16 +45,16 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: arn:aws:iam::832242454463:role/github-actions-deploy
           aws-region: us-east-1
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
 
       - name: Terraform Init
         run: terraform init -input=false -no-color

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -19,15 +19,15 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: '20'
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
 
       - name: Install tools
         run: |
@@ -59,16 +59,16 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: arn:aws:iam::832242454463:role/github-actions-deploy
           aws-region: us-east-1
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
 
       - name: Terraform Init
         run: terraform init -input=false -no-color

--- a/.github/workflows/notion.yml
+++ b/.github/workflows/notion.yml
@@ -12,6 +12,8 @@ on:
       - 'notion/**'
       - '.github/workflows/notion.yml'
 
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -19,15 +21,15 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
 
       - name: Install tools
         run: pip install black
@@ -56,29 +58,29 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: arn:aws:iam::832242454463:role/github-actions-deploy
           aws-region: us-east-1
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
 
       - name: Terraform Init
         run: terraform init -input=false -no-color
         working-directory: notion/terraform
 
       - name: Terraform Apply
-        run: >
-          terraform apply -auto-approve -input=false -no-color -lock-timeout=60s
-          -var="notion_token=${{ secrets.NOTION_TOKEN }}"
-          -var="notion_automations_db_id=${{ secrets.NOTION_AUTOMATIONS_DB_ID }}"
+        env:
+          TF_VAR_notion_token: ${{ secrets.NOTION_TOKEN }}
+          TF_VAR_notion_automations_db_id: ${{ secrets.NOTION_AUTOMATIONS_DB_ID }}
+        run: terraform apply -auto-approve -input=false -no-color -lock-timeout=60s
         working-directory: notion/terraform

--- a/.github/workflows/notion.yml
+++ b/.github/workflows/notion.yml
@@ -1,0 +1,84 @@
+name: notion
+
+on:
+  push:
+    branches: [main, master, dev]
+    paths:
+      - 'notion/**'
+      - '.github/workflows/notion.yml'
+  pull_request:
+    branches: [main, master, dev]
+    paths:
+      - 'notion/**'
+      - '.github/workflows/notion.yml'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Install tools
+        run: pip install black
+
+      - name: Black Check
+        run: black --check notion/lambda/handler.py
+
+      - name: Terraform Format
+        run: terraform fmt -check -recursive
+        working-directory: notion/terraform
+
+      - name: Terraform Init
+        run: terraform init -backend=false
+        working-directory: notion/terraform
+
+      - name: Terraform Validate
+        run: terraform validate
+        working-directory: notion/terraform
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: lint
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::832242454463:role/github-actions-deploy
+          aws-region: us-east-1
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform Init
+        run: terraform init -input=false -no-color
+        working-directory: notion/terraform
+
+      - name: Terraform Apply
+        run: >
+          terraform apply -auto-approve -input=false -no-color -lock-timeout=60s
+          -var="notion_token=${{ secrets.NOTION_TOKEN }}"
+          -var="notion_automations_db_id=${{ secrets.NOTION_AUTOMATIONS_DB_ID }}"
+        working-directory: notion/terraform

--- a/.github/workflows/spotify.yml
+++ b/.github/workflows/spotify.yml
@@ -19,15 +19,15 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: '20'
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
 
       - name: Install tools
         run: |
@@ -59,24 +59,24 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: arn:aws:iam::832242454463:role/github-actions-deploy
           aws-region: us-east-1
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
 
       - name: Terraform Init
         run: terraform init -input=false -no-color
         working-directory: spotify/terraform
 
       - name: Terraform Apply
-        run: >
-          terraform apply -auto-approve -input=false -no-color -lock-timeout=60s
-          -var="spotify_client_id=${{ secrets.SPOTIPY_CLIENT_ID }}"
-          -var="spotify_client_secret=${{ secrets.SPOTIPY_CLIENT_SECRET }}"
+        env:
+          TF_VAR_spotify_client_id: ${{ secrets.SPOTIPY_CLIENT_ID }}
+          TF_VAR_spotify_client_secret: ${{ secrets.SPOTIPY_CLIENT_SECRET }}
+        run: terraform apply -auto-approve -input=false -no-color -lock-timeout=60s
         working-directory: spotify/terraform

--- a/assets/terraform/main.tf
+++ b/assets/terraform/main.tf
@@ -90,7 +90,7 @@ resource "aws_cloudfront_distribution" "this" {
   viewer_certificate {
     acm_certificate_arn      = var.certificate_arn
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1.2_2023_04"
+    minimum_protocol_version = "TLSv1.2_2025"
   }
 
   restrictions {

--- a/assets/terraform/main.tf
+++ b/assets/terraform/main.tf
@@ -90,7 +90,7 @@ resource "aws_cloudfront_distribution" "this" {
   viewer_certificate {
     acm_certificate_arn      = var.certificate_arn
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1.2_2021"
+    minimum_protocol_version = "TLSv1.2_2023_04"
   }
 
   restrictions {

--- a/frontend/terraform/main.tf
+++ b/frontend/terraform/main.tf
@@ -169,7 +169,7 @@ resource "aws_cloudfront_distribution" "this" {
   viewer_certificate {
     acm_certificate_arn      = var.certificate_arn
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1.2_2021"
+    minimum_protocol_version = "TLSv1.2_2023_04"
   }
 
   restrictions {

--- a/frontend/terraform/main.tf
+++ b/frontend/terraform/main.tf
@@ -169,7 +169,7 @@ resource "aws_cloudfront_distribution" "this" {
   viewer_certificate {
     acm_certificate_arn      = var.certificate_arn
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1.2_2023_04"
+    minimum_protocol_version = "TLSv1.2_2025"
   }
 
   restrictions {

--- a/games/main.tf
+++ b/games/main.tf
@@ -149,7 +149,7 @@ resource "aws_cloudfront_distribution" "this" {
   viewer_certificate {
     acm_certificate_arn      = var.certificate_arn
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1.2_2023_04"
+    minimum_protocol_version = "TLSv1.2_2025"
   }
 
   restrictions {

--- a/games/main.tf
+++ b/games/main.tf
@@ -149,7 +149,7 @@ resource "aws_cloudfront_distribution" "this" {
   viewer_certificate {
     acm_certificate_arn      = var.certificate_arn
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1.2_2021"
+    minimum_protocol_version = "TLSv1.2_2023_04"
   }
 
   restrictions {

--- a/jupyter/main.tf
+++ b/jupyter/main.tf
@@ -91,7 +91,7 @@ resource "aws_cloudfront_distribution" "this" {
   viewer_certificate {
     acm_certificate_arn      = var.certificate_arn
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1.2_2023_04"
+    minimum_protocol_version = "TLSv1.2_2025"
   }
 
   restrictions {

--- a/jupyter/main.tf
+++ b/jupyter/main.tf
@@ -91,7 +91,7 @@ resource "aws_cloudfront_distribution" "this" {
   viewer_certificate {
     acm_certificate_arn      = var.certificate_arn
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1.2_2021"
+    minimum_protocol_version = "TLSv1.2_2023_04"
   }
 
   restrictions {

--- a/notion/lambda/.gitignore
+++ b/notion/lambda/.gitignore
@@ -1,0 +1,2 @@
+package/
+*.zip

--- a/notion/lambda/handler.py
+++ b/notion/lambda/handler.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from datetime import date, timedelta
+from datetime import date
 
 from notion_client import Client
 
@@ -69,7 +69,7 @@ def prop_date(page, name):
 
 
 def last_touched(page):
-    for key, val in page["properties"].items():
+    for _, val in page["properties"].items():
         if val.get("type") == "last_edited_time":
             t = val.get("last_edited_time", "")
             return date.fromisoformat(t[:10]) if t else None
@@ -93,7 +93,8 @@ def compute_target_priority(automation, days_since_creation):
 
 def maybe_escalate(task, automation, today):
     """Escalate based on Date Created. Used by monthly and escalation_only.
-    after_completion uses period as cycle start instead (see handle_after_completion)."""
+    after_completion uses period as cycle start instead (see handle_after_completion).
+    """
     status = prop_select(task, "Status")
     if status == DONE_STATUS:
         return
@@ -115,7 +116,9 @@ def maybe_escalate(task, automation, today):
 
 def create_task(automation, period, today):
     automation_id = automation["id"]
-    template = prop_text(automation, "task_name_template") or prop_text(automation, "Name")
+    template = prop_text(automation, "task_name_template") or prop_text(
+        automation, "Name"
+    )
     name = format_name(template, period, today)
     initial = compute_target_priority(automation, 0)
     notion.pages.create(
@@ -132,8 +135,18 @@ def create_task(automation, period, today):
 
 def format_name(template, period, today):
     month_names = [
-        "January", "February", "March", "April", "May", "June",
-        "July", "August", "September", "October", "November", "December",
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
     ]
     return template.format(
         month_name=month_names[today.month - 1],
@@ -162,7 +175,10 @@ def handle_monthly(automation, today):
         TASKS_DB_ID,
         {
             "and": [
-                {"property": "automation_id", "rich_text": {"equals": automation["id"]}},
+                {
+                    "property": "automation_id",
+                    "rich_text": {"equals": automation["id"]},
+                },
                 {"property": "period", "rich_text": {"equals": period}},
             ]
         },
@@ -177,7 +193,9 @@ def handle_monthly(automation, today):
 def handle_after_completion(automation, today):
     recurrence_days = prop_number(automation, "recurrence_days")
     if recurrence_days is None:
-        logger.warning(f"after_completion automation {automation['id']} missing recurrence_days")
+        logger.warning(
+            f"after_completion automation {automation['id']} missing recurrence_days"
+        )
         return
 
     existing = query_all(
@@ -196,7 +214,9 @@ def handle_after_completion(automation, today):
         # Use period as cycle start date for escalation (survives resets)
         cycle_start_raw = prop_text(task, "period")
         try:
-            cycle_start = date.fromisoformat(cycle_start_raw) if cycle_start_raw else None
+            cycle_start = (
+                date.fromisoformat(cycle_start_raw) if cycle_start_raw else None
+            )
         except ValueError:
             cycle_start = None
         if cycle_start:
@@ -234,7 +254,10 @@ def handle_escalation_only(automation, today):
         TASKS_DB_ID,
         {
             "and": [
-                {"property": "automation_id", "rich_text": {"equals": automation["id"]}},
+                {
+                    "property": "automation_id",
+                    "rich_text": {"equals": automation["id"]},
+                },
                 {"property": "period", "rich_text": {"equals": "singleton"}},
             ]
         },
@@ -248,7 +271,9 @@ def handle_escalation_only(automation, today):
                 page_id=automation["id"],
                 properties={"active": {"checkbox": False}},
             )
-            logger.info(f"Auto-disabled escalation_only automation {automation['id']} (task done)")
+            logger.info(
+                f"Auto-disabled escalation_only automation {automation['id']} (task done)"
+            )
         else:
             maybe_escalate(task, automation, today)
     else:
@@ -280,7 +305,9 @@ def handler(event, context):
         recurrence_type = prop_select(automation, "recurrence_type")
         fn = HANDLERS.get(recurrence_type)
         if not fn:
-            logger.warning(f"Unknown recurrence_type '{recurrence_type}' on '{automation_name}'")
+            logger.warning(
+                f"Unknown recurrence_type '{recurrence_type}' on '{automation_name}'"
+            )
             continue
         try:
             fn(automation, today)

--- a/notion/lambda/handler.py
+++ b/notion/lambda/handler.py
@@ -1,0 +1,288 @@
+import logging
+import os
+from datetime import date, timedelta
+
+from notion_client import Client
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+notion = Client(auth=os.environ["NOTION_TOKEN"])
+AUTOMATIONS_DB_ID = os.environ["NOTION_AUTOMATIONS_DB_ID"]
+TASKS_DB_ID = os.environ["NOTION_TASKS_DB_ID"]
+
+PRIORITY_RANK = {"P3": 0, "P2": 1, "P1": 2}
+DONE_STATUS = "Done 🙌"
+
+
+# ---------------------------------------------------------------------------
+# Notion helpers
+# ---------------------------------------------------------------------------
+
+
+def query_all(database_id, filter_obj=None):
+    """Paginate through all results from a database query."""
+    results = []
+    kwargs = {"database_id": database_id}
+    if filter_obj:
+        kwargs["filter"] = filter_obj
+    while True:
+        resp = notion.databases.query(**kwargs)
+        results.extend(resp["results"])
+        if not resp.get("has_more"):
+            break
+        kwargs["start_cursor"] = resp["next_cursor"]
+    return results
+
+
+def prop_text(page, name):
+    p = page["properties"].get(name, {})
+    items = p.get("rich_text") or p.get("title") or []
+    return items[0]["plain_text"] if items else None
+
+
+def prop_number(page, name):
+    p = page["properties"].get(name, {})
+    return p.get("number")
+
+
+def prop_select(page, name):
+    p = page["properties"].get(name, {})
+    s = p.get("select")
+    return s["name"] if s else None
+
+
+def prop_checkbox(page, name):
+    p = page["properties"].get(name, {})
+    return p.get("checkbox", False)
+
+
+def prop_date(page, name):
+    """Return the created_time date for system props, or start date for date props."""
+    p = page["properties"].get(name, {})
+    if p.get("type") == "created_time":
+        val = p.get("created_time", "")
+    else:
+        d = p.get("date") or {}
+        val = d.get("start", "")
+    return date.fromisoformat(val[:10]) if val else None
+
+
+def last_touched(page):
+    for key, val in page["properties"].items():
+        if val.get("type") == "last_edited_time":
+            t = val.get("last_edited_time", "")
+            return date.fromisoformat(t[:10]) if t else None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+
+def compute_target_priority(automation, days_since_creation):
+    p2 = prop_number(automation, "escalate_p2_after_days")
+    p1 = prop_number(automation, "escalate_p1_after_days")
+    if p1 is not None and days_since_creation >= p1:
+        return "P1"
+    if p2 is not None and days_since_creation >= p2:
+        return "P2"
+    return "P3"
+
+
+def maybe_escalate(task, automation, today):
+    """Escalate based on Date Created. Used by monthly and escalation_only.
+    after_completion uses period as cycle start instead (see handle_after_completion)."""
+    status = prop_select(task, "Status")
+    if status == DONE_STATUS:
+        return
+    created = prop_date(task, "Date Created")
+    if not created:
+        return
+    days = (today - created).days
+    target = compute_target_priority(automation, days)
+    current_rank = PRIORITY_RANK.get(status, 0)
+    target_rank = PRIORITY_RANK.get(target, 0)
+    if target_rank > current_rank:
+        notion.pages.update(
+            page_id=task["id"],
+            properties={"Status": {"select": {"name": target}}},
+        )
+        name = prop_text(task, "Name")
+        logger.info(f"Escalated '{name}' from {status} → {target}")
+
+
+def create_task(automation, period, today):
+    automation_id = automation["id"]
+    template = prop_text(automation, "task_name_template") or prop_text(automation, "Name")
+    name = format_name(template, period, today)
+    initial = compute_target_priority(automation, 0)
+    notion.pages.create(
+        parent={"database_id": TASKS_DB_ID},
+        properties={
+            "Name": {"title": [{"text": {"content": name}}]},
+            "Status": {"select": {"name": initial}},
+            "automation_id": {"rich_text": [{"text": {"content": automation_id}}]},
+            "period": {"rich_text": [{"text": {"content": period}}]},
+        },
+    )
+    logger.info(f"Created task '{name}' (automation={automation_id}, period={period})")
+
+
+def format_name(template, period, today):
+    month_names = [
+        "January", "February", "March", "April", "May", "June",
+        "July", "August", "September", "October", "November", "December",
+    ]
+    return template.format(
+        month_name=month_names[today.month - 1],
+        month_short=month_names[today.month - 1][:3],
+        month_num=f"{today.month:02d}",
+        year=today.year,
+        year_short=str(today.year)[2:],
+        period=period,
+        date=today.isoformat(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-type handlers
+# ---------------------------------------------------------------------------
+
+
+def handle_monthly(automation, today):
+    create_on_day = prop_number(automation, "create_on_day")
+    if create_on_day is None:
+        logger.warning(f"monthly automation {automation['id']} missing create_on_day")
+        return
+
+    period = today.strftime("%Y-%m")
+    existing = query_all(
+        TASKS_DB_ID,
+        {
+            "and": [
+                {"property": "automation_id", "rich_text": {"equals": automation["id"]}},
+                {"property": "period", "rich_text": {"equals": period}},
+            ]
+        },
+    )
+
+    if existing:
+        maybe_escalate(existing[0], automation, today)
+    elif today.day == int(create_on_day):
+        create_task(automation, period, today)
+
+
+def handle_after_completion(automation, today):
+    recurrence_days = prop_number(automation, "recurrence_days")
+    if recurrence_days is None:
+        logger.warning(f"after_completion automation {automation['id']} missing recurrence_days")
+        return
+
+    existing = query_all(
+        TASKS_DB_ID,
+        {"property": "automation_id", "rich_text": {"equals": automation["id"]}},
+    )
+
+    if not existing:
+        create_task(automation, today.isoformat(), today)
+        return
+
+    task = existing[0]
+    status = prop_select(task, "Status")
+
+    if status != DONE_STATUS:
+        # Use period as cycle start date for escalation (survives resets)
+        cycle_start_raw = prop_text(task, "period")
+        try:
+            cycle_start = date.fromisoformat(cycle_start_raw) if cycle_start_raw else None
+        except ValueError:
+            cycle_start = None
+        if cycle_start:
+            days = (today - cycle_start).days
+            target = compute_target_priority(automation, days)
+            current_rank = PRIORITY_RANK.get(status, 0)
+            if PRIORITY_RANK.get(target, 0) > current_rank:
+                notion.pages.update(
+                    page_id=task["id"],
+                    properties={"Status": {"select": {"name": target}}},
+                )
+                name = prop_text(task, "Name")
+                logger.info(f"Escalated '{name}' from {status} → {target}")
+        return
+
+    # Task is Done — check if interval has elapsed since completion
+    done_date = last_touched(task)
+    if not done_date or (today - done_date).days < int(recurrence_days):
+        return
+
+    # Reset the existing page for the next cycle
+    name = prop_text(task, "Name")
+    notion.pages.update(
+        page_id=task["id"],
+        properties={
+            "Status": {"select": {"name": "P3"}},
+            "period": {"rich_text": [{"text": {"content": today.isoformat()}}]},
+        },
+    )
+    logger.info(f"Reset '{name}' for new cycle (automation={automation['id']})")
+
+
+def handle_escalation_only(automation, today):
+    existing = query_all(
+        TASKS_DB_ID,
+        {
+            "and": [
+                {"property": "automation_id", "rich_text": {"equals": automation["id"]}},
+                {"property": "period", "rich_text": {"equals": "singleton"}},
+            ]
+        },
+    )
+
+    if existing:
+        task = existing[0]
+        if prop_select(task, "Status") == DONE_STATUS:
+            # Auto-disable the automation
+            notion.pages.update(
+                page_id=automation["id"],
+                properties={"active": {"checkbox": False}},
+            )
+            logger.info(f"Auto-disabled escalation_only automation {automation['id']} (task done)")
+        else:
+            maybe_escalate(task, automation, today)
+    else:
+        create_task(automation, "singleton", today)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+HANDLERS = {
+    "monthly": handle_monthly,
+    "after_completion": handle_after_completion,
+    "escalation_only": handle_escalation_only,
+}
+
+
+def handler(event, context):
+    today = date.today()
+    automations = query_all(
+        AUTOMATIONS_DB_ID,
+        {"property": "active", "checkbox": {"equals": True}},
+    )
+    logger.info(f"Processing {len(automations)} active automations for {today}")
+
+    for automation in automations:
+        automation_name = prop_text(automation, "Name")
+        recurrence_type = prop_select(automation, "recurrence_type")
+        fn = HANDLERS.get(recurrence_type)
+        if not fn:
+            logger.warning(f"Unknown recurrence_type '{recurrence_type}' on '{automation_name}'")
+            continue
+        try:
+            fn(automation, today)
+        except Exception as e:
+            logger.error(f"Error processing '{automation_name}': {e}", exc_info=True)

--- a/notion/lambda/requirements.txt
+++ b/notion/lambda/requirements.txt
@@ -1,0 +1,1 @@
+notion-client==2.3.0

--- a/notion/terraform/backend.tf
+++ b/notion/terraform/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "ctbus-tfstates"
+    key          = "ctbus_site/notion.tfstate"
+    region       = "us-east-1"
+    use_lockfile = true
+    encrypt      = true
+  }
+}

--- a/notion/terraform/main.tf
+++ b/notion/terraform/main.tf
@@ -56,19 +56,20 @@ resource "aws_iam_role_policy_attachment" "notion_automations_basic" {
 # ---------------------------------------------------------------------------
 
 resource "aws_lambda_function" "notion_automations" {
-  function_name    = "notion-automations"
-  role             = aws_iam_role.notion_automations.arn
-  handler          = "handler.handler"
-  runtime          = "python3.12"
-  filename         = data.archive_file.notion_automations.output_path
-  source_code_hash = data.archive_file.notion_automations.output_base64sha256
-  timeout          = 60
+  function_name                  = "notion-automations"
+  role                           = aws_iam_role.notion_automations.arn
+  handler                        = "handler.handler"
+  runtime                        = "python3.12"
+  filename                       = data.archive_file.notion_automations.output_path
+  source_code_hash               = data.archive_file.notion_automations.output_base64sha256
+  timeout                        = 60
+  reserved_concurrent_executions = 5
 
   environment {
     variables = {
-      NOTION_TOKEN              = var.notion_token
-      NOTION_AUTOMATIONS_DB_ID  = var.notion_automations_db_id
-      NOTION_TASKS_DB_ID        = var.notion_tasks_db_id
+      NOTION_TOKEN             = var.notion_token
+      NOTION_AUTOMATIONS_DB_ID = var.notion_automations_db_id
+      NOTION_TASKS_DB_ID       = var.notion_tasks_db_id
     }
   }
 }

--- a/notion/terraform/main.tf
+++ b/notion/terraform/main.tf
@@ -1,0 +1,97 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+# ---------------------------------------------------------------------------
+# Build Lambda package
+# ---------------------------------------------------------------------------
+
+resource "null_resource" "lambda_build" {
+  triggers = {
+    handler      = filemd5("${path.module}/../lambda/handler.py")
+    requirements = filemd5("${path.module}/../lambda/requirements.txt")
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      rm -rf ${path.module}/../lambda/package
+      pip install -r ${path.module}/../lambda/requirements.txt \
+        -t ${path.module}/../lambda/package/ --quiet --upgrade
+      cp ${path.module}/../lambda/handler.py ${path.module}/../lambda/package/
+    EOT
+  }
+}
+
+data "archive_file" "notion_automations" {
+  type        = "zip"
+  source_dir  = "${path.module}/../lambda/package"
+  output_path = "${path.module}/../lambda/notion-automations.zip"
+  depends_on  = [null_resource.lambda_build]
+}
+
+# ---------------------------------------------------------------------------
+# IAM
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_role" "notion_automations" {
+  name = "notion-automations-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "notion_automations_basic" {
+  role       = aws_iam_role.notion_automations.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# ---------------------------------------------------------------------------
+# Lambda
+# ---------------------------------------------------------------------------
+
+resource "aws_lambda_function" "notion_automations" {
+  function_name    = "notion-automations"
+  role             = aws_iam_role.notion_automations.arn
+  handler          = "handler.handler"
+  runtime          = "python3.12"
+  filename         = data.archive_file.notion_automations.output_path
+  source_code_hash = data.archive_file.notion_automations.output_base64sha256
+  timeout          = 60
+
+  environment {
+    variables = {
+      NOTION_TOKEN              = var.notion_token
+      NOTION_AUTOMATIONS_DB_ID  = var.notion_automations_db_id
+      NOTION_TASKS_DB_ID        = var.notion_tasks_db_id
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# EventBridge — daily at 3am EST (8am UTC)
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudwatch_event_rule" "notion_automations_daily" {
+  name                = "notion-automations-daily"
+  schedule_expression = "cron(0 8 * * ? *)"
+}
+
+resource "aws_cloudwatch_event_target" "notion_automations" {
+  rule      = aws_cloudwatch_event_rule.notion_automations_daily.name
+  target_id = "NotionAutomations"
+  arn       = aws_lambda_function.notion_automations.arn
+}
+
+resource "aws_lambda_permission" "notion_automations_eventbridge" {
+  statement_id  = "AllowEventBridge"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.notion_automations.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.notion_automations_daily.arn
+}

--- a/notion/terraform/variables.tf
+++ b/notion/terraform/variables.tf
@@ -1,0 +1,16 @@
+variable "notion_token" {
+  type        = string
+  description = "Notion internal integration token"
+  sensitive   = true
+}
+
+variable "notion_automations_db_id" {
+  type        = string
+  description = "Notion Automations database ID"
+}
+
+variable "notion_tasks_db_id" {
+  type        = string
+  description = "Notion Tasks database ID"
+  default     = "647c5b7e-4759-4886-9e79-4877d83b0a1d"
+}


### PR DESCRIPTION
## Summary

- New `notion/` service: daily Lambda (3am EST via EventBridge) that creates and escalates Notion tasks automatically
- Automation rules live in a **Task Automations** database in Notion — editable from mobile, no redeploy needed
- Three recurrence types: `monthly` (rent), `after_completion` (oil change, dentist, physical), `escalation_only` (passport-style one-offs)
- `after_completion` tasks reuse the same Notion page across cycles so notes persist
- Adds `automation_id` + `period` properties to the existing Tasks database for idempotency
- S3 backend (`ctbus-tfstates/ctbus_site/notion.tfstate`), matches existing service pattern

## Test plan

- [ ] Manual `terraform apply` succeeds and creates Lambda + EventBridge rule
- [ ] Invoke Lambda manually via AWS console — verify it runs without error against Notion
- [ ] Confirm monthly rent task is created on the 1st (or test by temporarily setting `create_on_day` to today)
- [ ] Confirm `after_completion` tasks (oil change, dentist, physical) are created on first run
- [ ] Mark a task Done, verify it resets after the recurrence interval
- [ ] Verify priority escalation fires correctly after the configured day thresholds
- [ ] CI lint + terraform validate pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)