### PR TITLE
Fix easy Codacy issues: workflow permissions, unused vars, S3 hardening

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -4,13 +4,15 @@ on:
   push:
     branches: [main, master, dev]
     paths:
-      - 'assets/**'
-      - '.github/workflows/assets.yml'
+      - "assets/**"
+      - ".github/workflows/assets.yml"
   pull_request:
     branches: [main, master, dev]
     paths:
-      - 'assets/**'
-      - '.github/workflows/assets.yml'
+      - "assets/**"
+      - ".github/workflows/assets.yml"
+
+permissions: {}
 
 jobs:
   lint:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -4,13 +4,15 @@ on:
   push:
     branches: [main, master, dev]
     paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend.yml'
+      - "frontend/**"
+      - ".github/workflows/frontend.yml"
   pull_request:
     branches: [main, master, dev]
     paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend.yml'
+      - "frontend/**"
+      - ".github/workflows/frontend.yml"
+
+permissions: {}
 
 jobs:
   lint:
@@ -24,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2

--- a/.github/workflows/games.yml
+++ b/.github/workflows/games.yml
@@ -4,13 +4,15 @@ on:
   push:
     branches: [main, master, dev]
     paths:
-      - 'games/**'
-      - '.github/workflows/games.yml'
+      - "games/**"
+      - ".github/workflows/games.yml"
   pull_request:
     branches: [main, master, dev]
     paths:
-      - 'games/**'
-      - '.github/workflows/games.yml'
+      - "games/**"
+      - ".github/workflows/games.yml"
+
+permissions: {}
 
 jobs:
   lint:
@@ -24,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2

--- a/.github/workflows/health-checks.yml
+++ b/.github/workflows/health-checks.yml
@@ -6,11 +6,14 @@ on:
     paths:
       - .github/workflows/health-checks.yml
   schedule:
-    - cron: '3 3 * * 3'
+    - cron: "3 3 * * 3"
+
+permissions: {}
 
 jobs:
   broken-link-checker:
     runs-on: ubuntu-latest
+    permissions: {}
     container:
       image: ghcr.io/linkchecker/linkchecker:latest
 
@@ -20,7 +23,8 @@ jobs:
 
   critical-docs:
     runs-on: ubuntu-latest
-    
+    permissions: {}
+
     steps:
       - name: Verify critical docs' availability
         run: |

--- a/.github/workflows/jupyter.yml
+++ b/.github/workflows/jupyter.yml
@@ -4,13 +4,15 @@ on:
   push:
     branches: [main, master, dev]
     paths:
-      - 'jupyter/**'
-      - '.github/workflows/jupyter.yml'
+      - "jupyter/**"
+      - ".github/workflows/jupyter.yml"
   pull_request:
     branches: [main, master, dev]
     paths:
-      - 'jupyter/**'
-      - '.github/workflows/jupyter.yml'
+      - "jupyter/**"
+      - ".github/workflows/jupyter.yml"
+
+permissions: {}
 
 jobs:
   lint:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -4,13 +4,15 @@ on:
   push:
     branches: [main, master, dev]
     paths:
-      - 'maintenance/**'
-      - '.github/workflows/maintenance.yml'
+      - "maintenance/**"
+      - ".github/workflows/maintenance.yml"
   pull_request:
     branches: [main, master, dev]
     paths:
-      - 'maintenance/**'
-      - '.github/workflows/maintenance.yml'
+      - "maintenance/**"
+      - ".github/workflows/maintenance.yml"
+
+permissions: {}
 
 jobs:
   lint:
@@ -24,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2

--- a/.github/workflows/notion.yml
+++ b/.github/workflows/notion.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: [main, master, dev]
     paths:
-      - 'notion/**'
-      - '.github/workflows/notion.yml'
+      - "notion/**"
+      - ".github/workflows/notion.yml"
   pull_request:
     branches: [main, master, dev]
     paths:
-      - 'notion/**'
-      - '.github/workflows/notion.yml'
+      - "notion/**"
+      - ".github/workflows/notion.yml"
 
 permissions: {}
 
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12'
+          python-version: "3.12"
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: '3.12'
+          python-version: "3.12"
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2

--- a/.github/workflows/spotify.yml
+++ b/.github/workflows/spotify.yml
@@ -4,13 +4,15 @@ on:
   push:
     branches: [main, master, dev]
     paths:
-      - 'spotify/**'
-      - '.github/workflows/spotify.yml'
+      - "spotify/**"
+      - ".github/workflows/spotify.yml"
   pull_request:
     branches: [main, master, dev]
     paths:
-      - 'spotify/**'
-      - '.github/workflows/spotify.yml'
+      - "spotify/**"
+      - ".github/workflows/spotify.yml"
+
+permissions: {}
 
 jobs:
   lint:
@@ -24,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2

--- a/assets/terraform/main.tf
+++ b/assets/terraform/main.tf
@@ -11,6 +11,22 @@ resource "aws_s3_bucket" "this" {
   bucket = var.bucket_name
 }
 
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 locals {
   assets_dir  = "${path.root}/../files"
   asset_files = fileset(local.assets_dir, "**")

--- a/frontend/terraform/main.tf
+++ b/frontend/terraform/main.tf
@@ -32,6 +32,22 @@ resource "aws_s3_bucket" "this" {
   bucket = local.bucket_name
 }
 
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 locals {
   env         = terraform.workspace
   bucket_name = "${var.bucket_name}-${local.env}"

--- a/frontend/terraform/spa-redirect.js
+++ b/frontend/terraform/spa-redirect.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-unused-vars
 function handler(event) {
   var request = event.request;
   var uri = request.uri;

--- a/games/main.tf
+++ b/games/main.tf
@@ -19,6 +19,22 @@ resource "aws_s3_bucket" "this" {
   bucket = local.bucket_name
 }
 
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 locals {
   bucket_name = var.bucket_name
   hostname    = "games.charliebushman.com"

--- a/games/spa-redirect.js
+++ b/games/spa-redirect.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-unused-vars
 function handler(event) {
   var request = event.request;
   var uri = request.uri;

--- a/jupyter/main.tf
+++ b/jupyter/main.tf
@@ -10,6 +10,22 @@ resource "aws_s3_bucket" "this" {
   bucket = var.bucket_name
 }
 
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 locals {
   dist_dir   = "${path.root}/dist"
   dist_files = fileset(local.dist_dir, "**")


### PR DESCRIPTION
## Summary
- **CKV2_GHA_1** (7 workflows): Add top-level `permissions: {}` to restrict default write-all access; job-level overrides remain unchanged
- **no-unused-vars** (2 files): Suppress lint warning on CloudFront `handler` function — required by runtime, cannot be exported
- **CKV2_AWS_6** (4 TF modules): Add `aws_s3_bucket_public_access_block` to assets, frontend, games, jupyter
- **CKV_AWS_21** (4 TF modules): Add `aws_s3_bucket_versioning` to same 4 modules

## Test plan
- [ ] CI passes on all affected workflows (assets, frontend, games, jupyter, maintenance, spotify)
- [ ] Terraform fmt/validate passes for all 4 modified modules
- [ ] Prettier check passes for workflows and JS files
- [ ] Codacy reports should show these patterns resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)