### PR TITLE
Fix Codacy issues: no-undef globals, lifecycle rules, response headers, checkov skips

### DIFF
--- a/assets/terraform/main.tf
+++ b/assets/terraform/main.tf
@@ -8,6 +8,7 @@ data "aws_route53_zone" "selected" {
 
 
 resource "aws_s3_bucket" "this" {
+  #checkov:skip=CKV_AWS_145:KMS encryption for S3 is overkill for a personal portfolio site
   bucket = var.bucket_name
 }
 
@@ -24,6 +25,19 @@ resource "aws_s3_bucket_versioning" "this" {
   bucket = aws_s3_bucket.this.id
   versioning_configuration {
     status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    id     = "expire-old-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
   }
 }
 
@@ -78,7 +92,32 @@ resource "aws_s3_bucket_policy" "allow_cloudfront" {
   policy = data.aws_iam_policy_document.allow_cloudfront.json
 }
 
+resource "aws_cloudfront_response_headers_policy" "security_headers" {
+  name = "${var.bucket_name}-security-headers"
+
+  security_headers_config {
+    strict_transport_security {
+      access_control_max_age_sec = 31536000
+      include_subdomains         = true
+      override                   = true
+    }
+    content_type_options {
+      override = true
+    }
+    frame_options {
+      frame_option = "DENY"
+      override     = true
+    }
+    xss_protection {
+      mode_block = true
+      protection = true
+      override   = true
+    }
+  }
+}
+
 resource "aws_cloudfront_distribution" "this" {
+  #checkov:skip=CKV_AWS_86:CloudFront access logging not required for a personal portfolio
   enabled             = true
   default_root_object = "index.html"
   aliases             = [local.alias]
@@ -92,10 +131,11 @@ resource "aws_cloudfront_distribution" "this" {
   }
 
   default_cache_behavior {
-    target_origin_id       = "assets-bucket"
-    viewer_protocol_policy = "redirect-to-https"
-    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
-    cached_methods         = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id           = "assets-bucket"
+    viewer_protocol_policy     = "redirect-to-https"
+    allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+    cached_methods             = ["GET", "HEAD", "OPTIONS"]
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers.id
     forwarded_values {
       query_string = false
       cookies { forward = "none" }

--- a/assets/terraform/main.tf
+++ b/assets/terraform/main.tf
@@ -38,6 +38,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
     noncurrent_version_expiration {
       noncurrent_days = 90
     }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
   }
 }
 
@@ -99,6 +103,7 @@ resource "aws_cloudfront_response_headers_policy" "security_headers" {
     strict_transport_security {
       access_control_max_age_sec = 31536000
       include_subdomains         = true
+      preload                    = true
       override                   = true
     }
     content_type_options {

--- a/frontend/src/src/main.js
+++ b/frontend/src/src/main.js
@@ -1,3 +1,4 @@
+/* global Vue, VueRouter, Vuetify */
 const options = {
   moduleCache: {
     vue: Vue,

--- a/frontend/terraform/main.tf
+++ b/frontend/terraform/main.tf
@@ -59,6 +59,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
     noncurrent_version_expiration {
       noncurrent_days = 90
     }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
   }
 }
 
@@ -156,6 +160,7 @@ resource "aws_cloudfront_response_headers_policy" "security_headers" {
     strict_transport_security {
       access_control_max_age_sec = 31536000
       include_subdomains         = true
+      preload                    = true
       override                   = true
     }
     content_type_options {

--- a/frontend/terraform/main.tf
+++ b/frontend/terraform/main.tf
@@ -29,6 +29,7 @@ data "terraform_remote_state" "assets" {
 }
 
 resource "aws_s3_bucket" "this" {
+  #checkov:skip=CKV_AWS_145:KMS encryption for S3 is overkill for a personal portfolio site
   bucket = local.bucket_name
 }
 
@@ -45,6 +46,19 @@ resource "aws_s3_bucket_versioning" "this" {
   bucket = aws_s3_bucket.this.id
   versioning_configuration {
     status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    id     = "expire-old-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
   }
 }
 
@@ -135,7 +149,32 @@ resource "aws_cloudfront_function" "spa_rewrite" {
   code    = file("${path.module}/spa-redirect.js")
 }
 
+resource "aws_cloudfront_response_headers_policy" "security_headers" {
+  name = "${local.bucket_name}-security-headers"
+
+  security_headers_config {
+    strict_transport_security {
+      access_control_max_age_sec = 31536000
+      include_subdomains         = true
+      override                   = true
+    }
+    content_type_options {
+      override = true
+    }
+    frame_options {
+      frame_option = "DENY"
+      override     = true
+    }
+    xss_protection {
+      mode_block = true
+      protection = true
+      override   = true
+    }
+  }
+}
+
 resource "aws_cloudfront_distribution" "this" {
+  #checkov:skip=CKV_AWS_86:CloudFront access logging not required for a personal portfolio
   enabled             = true
   default_root_object = "index.html"
   aliases             = local.aliases
@@ -149,10 +188,11 @@ resource "aws_cloudfront_distribution" "this" {
   }
 
   default_cache_behavior {
-    target_origin_id       = "s3-frontend"
-    viewer_protocol_policy = "redirect-to-https"
-    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
-    cached_methods         = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id           = "s3-frontend"
+    viewer_protocol_policy     = "redirect-to-https"
+    allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+    cached_methods             = ["GET", "HEAD", "OPTIONS"]
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers.id
 
     function_association {
       event_type   = "viewer-request"

--- a/games/dev-server.js
+++ b/games/dev-server.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 const fs = require("fs");
 const http = require("http");
 const path = require("path");
@@ -10,15 +9,16 @@ const providedPortIndex = args.findIndex(
 const requestedPort =
   providedPortIndex >= 0 && args[providedPortIndex + 1]
     ? Number(args[providedPortIndex + 1])
-    : Number(process.env.PORT || 4173);
+    : Number(process.env.PORT || 4173); // eslint-disable-line turbo/no-undeclared-env-vars
 const port =
   Number.isFinite(requestedPort) && requestedPort > 0 ? requestedPort : 4173;
 const contentRoot = path.resolve(__dirname, "src");
 const assetsRoot = path.resolve(__dirname, "../assets/files");
 const assetsBaseUrl =
-  process.env.ASSETS_BASE_URL || `http://localhost:${port}/assets`;
-const envName = process.env.ENV_NAME || "local";
+  process.env.ASSETS_BASE_URL || `http://localhost:${port}/assets`; // eslint-disable-line turbo/no-undeclared-env-vars
+const envName = process.env.ENV_NAME || "local"; // eslint-disable-line turbo/no-undeclared-env-vars
 
+// eslint-disable-next-line @shopify/prefer-module-scope-constants
 const MIME_TYPES = {
   ".html": "text/html",
   ".js": "application/javascript",
@@ -32,6 +32,7 @@ const MIME_TYPES = {
   ".gif": "image/gif",
 };
 
+// eslint-disable-next-line @shopify/prefer-module-scope-constants
 const TEXT_EXTENSIONS = new Set([".html", ".js", ".css", ".json", ".svg"]);
 
 const placeholderValues = {

--- a/games/main.tf
+++ b/games/main.tf
@@ -46,6 +46,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
     noncurrent_version_expiration {
       noncurrent_days = 90
     }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
   }
 }
 
@@ -136,6 +140,7 @@ resource "aws_cloudfront_response_headers_policy" "security_headers" {
     strict_transport_security {
       access_control_max_age_sec = 31536000
       include_subdomains         = true
+      preload                    = true
       override                   = true
     }
     content_type_options {

--- a/games/main.tf
+++ b/games/main.tf
@@ -16,6 +16,7 @@ data "terraform_remote_state" "assets" {
 }
 
 resource "aws_s3_bucket" "this" {
+  #checkov:skip=CKV_AWS_145:KMS encryption for S3 is overkill for a personal portfolio site
   bucket = local.bucket_name
 }
 
@@ -32,6 +33,19 @@ resource "aws_s3_bucket_versioning" "this" {
   bucket = aws_s3_bucket.this.id
   versioning_configuration {
     status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    id     = "expire-old-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
   }
 }
 
@@ -115,7 +129,32 @@ resource "aws_cloudfront_function" "spa_rewrite" {
   code    = file("${path.module}/spa-redirect.js")
 }
 
+resource "aws_cloudfront_response_headers_policy" "security_headers" {
+  name = "${local.bucket_name}-security-headers"
+
+  security_headers_config {
+    strict_transport_security {
+      access_control_max_age_sec = 31536000
+      include_subdomains         = true
+      override                   = true
+    }
+    content_type_options {
+      override = true
+    }
+    frame_options {
+      frame_option = "DENY"
+      override     = true
+    }
+    xss_protection {
+      mode_block = true
+      protection = true
+      override   = true
+    }
+  }
+}
+
 resource "aws_cloudfront_distribution" "this" {
+  #checkov:skip=CKV_AWS_86:CloudFront access logging not required for a personal portfolio
   enabled             = true
   default_root_object = "index.html"
   aliases             = local.aliases
@@ -129,10 +168,11 @@ resource "aws_cloudfront_distribution" "this" {
   }
 
   default_cache_behavior {
-    target_origin_id       = "s3-games"
-    viewer_protocol_policy = "redirect-to-https"
-    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
-    cached_methods         = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id           = "s3-games"
+    viewer_protocol_policy     = "redirect-to-https"
+    allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+    cached_methods             = ["GET", "HEAD", "OPTIONS"]
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers.id
 
     function_association {
       event_type   = "viewer-request"

--- a/games/src/src/App.js
+++ b/games/src/src/App.js
@@ -1,3 +1,4 @@
+/* global React */
 const { useState } = React;
 
 const styles = {

--- a/games/src/src/main.js
+++ b/games/src/src/main.js
@@ -1,4 +1,5 @@
-import { App } from "./App.js";
+/* global React, ReactDOM */
+import { App } from "./App.js"; // eslint-disable-line import-alias/import-alias
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(React.createElement(App));

--- a/jupyter/main.tf
+++ b/jupyter/main.tf
@@ -37,6 +37,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
     noncurrent_version_expiration {
       noncurrent_days = 90
     }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
   }
 }
 
@@ -100,6 +104,7 @@ resource "aws_cloudfront_response_headers_policy" "security_headers" {
     strict_transport_security {
       access_control_max_age_sec = 31536000
       include_subdomains         = true
+      preload                    = true
       override                   = true
     }
     content_type_options {

--- a/jupyter/main.tf
+++ b/jupyter/main.tf
@@ -7,6 +7,7 @@ data "aws_route53_zone" "selected" {
 }
 
 resource "aws_s3_bucket" "this" {
+  #checkov:skip=CKV_AWS_145:KMS encryption for S3 is overkill for a personal portfolio site
   bucket = var.bucket_name
 }
 
@@ -23,6 +24,19 @@ resource "aws_s3_bucket_versioning" "this" {
   bucket = aws_s3_bucket.this.id
   versioning_configuration {
     status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    id     = "expire-old-versions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
   }
 }
 
@@ -79,7 +93,32 @@ resource "aws_s3_bucket_policy" "allow_cloudfront" {
   policy = data.aws_iam_policy_document.allow_cloudfront.json
 }
 
+resource "aws_cloudfront_response_headers_policy" "security_headers" {
+  name = "${var.bucket_name}-security-headers"
+
+  security_headers_config {
+    strict_transport_security {
+      access_control_max_age_sec = 31536000
+      include_subdomains         = true
+      override                   = true
+    }
+    content_type_options {
+      override = true
+    }
+    frame_options {
+      frame_option = "DENY"
+      override     = true
+    }
+    xss_protection {
+      mode_block = true
+      protection = true
+      override   = true
+    }
+  }
+}
+
 resource "aws_cloudfront_distribution" "this" {
+  #checkov:skip=CKV_AWS_86:CloudFront access logging not required for a personal portfolio
   enabled             = true
   default_root_object = "index.html"
   aliases             = [local.alias]
@@ -93,10 +132,11 @@ resource "aws_cloudfront_distribution" "this" {
   }
 
   default_cache_behavior {
-    target_origin_id       = "jupyter-bucket"
-    viewer_protocol_policy = "redirect-to-https"
-    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
-    cached_methods         = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id           = "jupyter-bucket"
+    viewer_protocol_policy     = "redirect-to-https"
+    allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+    cached_methods             = ["GET", "HEAD", "OPTIONS"]
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers.id
     forwarded_values {
       query_string = false
       cookies { forward = "none" }

--- a/maintenance/terraform/main.tf
+++ b/maintenance/terraform/main.tf
@@ -27,20 +27,23 @@ resource "aws_iam_role_policy_attachment" "maintenance_lambda_basic" {
 }
 
 resource "aws_lambda_function" "maintenance" {
-  function_name    = "maintenance"
-  role             = aws_iam_role.maintenance_lambda.arn
-  handler          = "index.handler"
-  runtime          = "nodejs20.x"
-  filename         = data.archive_file.maintenance.output_path
-  source_code_hash = data.archive_file.maintenance.output_base64sha256
+  function_name                  = "maintenance"
+  role                           = aws_iam_role.maintenance_lambda.arn
+  handler                        = "index.handler"
+  runtime                        = "nodejs20.x"
+  filename                       = data.archive_file.maintenance.output_path
+  source_code_hash               = data.archive_file.maintenance.output_base64sha256
+  reserved_concurrent_executions = 5
 }
 
 resource "aws_lambda_function_url" "maintenance" {
+  #checkov:skip=CKV_AWS_258:Lambda URL is intentionally public — maintenance status endpoint
   function_name      = aws_lambda_function.maintenance.arn
   authorization_type = "NONE"
 }
 
 resource "aws_lambda_permission" "maintenance_url" {
+  #checkov:skip=CKV_AWS_301:Lambda is intentionally publicly accessible via function URL
   statement_id           = "AllowPublicAccess"
   action                 = "lambda:InvokeFunctionUrl"
   function_name          = aws_lambda_function.maintenance.function_name

--- a/notion/terraform/main.tf
+++ b/notion/terraform/main.tf
@@ -56,6 +56,7 @@ resource "aws_iam_role_policy_attachment" "notion_automations_basic" {
 # ---------------------------------------------------------------------------
 
 resource "aws_lambda_function" "notion_automations" {
+  #checkov:skip=CKV_AWS_173:KMS encryption for Lambda env vars is overkill for a personal portfolio
   function_name                  = "notion-automations"
   role                           = aws_iam_role.notion_automations.arn
   handler                        = "handler.handler"

--- a/spotify/lambda/index.js
+++ b/spotify/lambda/index.js
@@ -1,4 +1,6 @@
+// eslint-disable-next-line turbo/no-undeclared-env-vars, @shopify/prefer-module-scope-constants
 const CLIENT_ID = process.env.SPOTIFY_CLIENT_ID;
+// eslint-disable-next-line turbo/no-undeclared-env-vars, @shopify/prefer-module-scope-constants
 const CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET;
 
 exports.handler = async function (event) {

--- a/spotify/terraform/main.tf
+++ b/spotify/terraform/main.tf
@@ -27,13 +27,15 @@ resource "aws_iam_role_policy_attachment" "spotify_lambda_basic" {
 }
 
 resource "aws_lambda_function" "spotify_playlists" {
-  function_name    = "spotify-playlists"
-  role             = aws_iam_role.spotify_lambda.arn
-  handler          = "index.handler"
-  runtime          = "nodejs20.x"
-  filename         = data.archive_file.spotify_playlists.output_path
-  source_code_hash = data.archive_file.spotify_playlists.output_base64sha256
-  timeout          = 15
+  #checkov:skip=CKV_AWS_173:KMS encryption for Lambda env vars is overkill for a personal portfolio
+  function_name                  = "spotify-playlists"
+  role                           = aws_iam_role.spotify_lambda.arn
+  handler                        = "index.handler"
+  runtime                        = "nodejs20.x"
+  filename                       = data.archive_file.spotify_playlists.output_path
+  source_code_hash               = data.archive_file.spotify_playlists.output_base64sha256
+  timeout                        = 15
+  reserved_concurrent_executions = 10
   environment {
     variables = {
       SPOTIFY_CLIENT_ID     = var.spotify_client_id
@@ -43,11 +45,13 @@ resource "aws_lambda_function" "spotify_playlists" {
 }
 
 resource "aws_lambda_function_url" "spotify_playlists" {
+  #checkov:skip=CKV_AWS_258:Lambda URL is intentionally public — CORS-gated Spotify proxy for the portfolio frontend
   function_name      = aws_lambda_function.spotify_playlists.arn
   authorization_type = "NONE"
 }
 
 resource "aws_lambda_permission" "spotify_playlists_url" {
+  #checkov:skip=CKV_AWS_301:Lambda is intentionally publicly accessible via function URL
   statement_id           = "AllowPublicAccess"
   action                 = "lambda:InvokeFunctionUrl"
   function_name          = aws_lambda_function.spotify_playlists.function_name


### PR DESCRIPTION
## Summary

- **JS `no-undef` (10 issues):** Add `/* global Vue, VueRouter, Vuetify */` to `frontend/src/src/main.js` and `/* global React, ReactDOM */` to `games/src/src/main.js` + `App.js` — these are CDN globals that ESLint can't see
- **Shebang (1 issue):** Remove `#!/usr/bin/env node` from `games/dev-server.js` — file is not a CLI script
- **ESLint false positives (7 issues):** Add inline `eslint-disable` comments for `turbo/no-undeclared-env-vars` and `@shopify/prefer-module-scope-constants` in `dev-server.js` and `spotify/lambda/index.js` — these plugins don't apply to this project but Codacy runs them
- **Lambda concurrency (2 issues, CKV_AWS_115):** Add `reserved_concurrent_executions` to Spotify (10) and Maintenance (5) lambdas
- **S3 lifecycle (4 issues, CKV2_AWS_61):** Add `aws_s3_bucket_lifecycle_configuration` to frontend, games, assets, jupyter — 90-day noncurrent version expiry
- **CloudFront response headers (4 issues, CKV2_AWS_32):** Add `aws_cloudfront_response_headers_policy` with HSTS, X-Frame-Options, XSS protection, content-type sniffing prevention to all 4 distributions — genuine security improvement
- **Intentional checkov skips:** CKV_AWS_258/CKV_AWS_301 (public Lambda URLs by design), CKV_AWS_173/CKV_AWS_145 (KMS overkill for personal portfolio), CKV_AWS_86 (CloudFront logging not needed for portfolio)

## Test plan

- [ ] CI passes: `frontend.yml`, `assets.yml`, `spotify.yml`, `maintenance.yml`, `jupyter.yml` (Prettier + Terraform fmt/validate)
- [ ] Codacy issue count drops from 56 → ~13 (remaining: compat/Opera Mini false positives that can't be suppressed without .eslintrc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)